### PR TITLE
Implement a todo feature.

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,16 @@
                     "default": "",
                     "description": "Where to place the tasks. (Default is empty, which means after the header)"
                 },
+                "journal.tpl-todo": {
+                    "type": "string",
+                    "default": "- [ ] TODO: {content}",
+                    "description": "The template string for new todos. "
+                },
+                "journal.tpl-todo-after": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Where to place the todos. (Default is empty, which means after the header)"
+                },
                 "journal.tpl-files": {
                     "type": "string",
                     "default": "- NOTE: [{label}]({link})",

--- a/src/util/model/conf.ts
+++ b/src/util/model/conf.ts
@@ -91,4 +91,7 @@ export class Configuration {
     public getTaskTemplate(): TemplateInfo {
         return new TemplateInfo(this.config.get<string>('tpl-task'), this.config.get<string>('tpl-task-after')); 
     }
+    public getTodoTemplate() {
+        return new TemplateInfo(this.config.get<string>('tpl-todo'), this.config.get<string>('tpl-todo-after'));
+    }
 }

--- a/src/util/writer.ts
+++ b/src/util/writer.ts
@@ -137,6 +137,8 @@ export class Writer {
             return this.writeStringToFile(doc, content, pos);
         } else if (input.flags.match("task")) {
             return this.insertContent(doc, this.config.getTaskTemplate(), ["{content}", input.memo]); 
+        } else if (input.flags.match("todo")){
+            return this.insertContent(doc, this.config.getTodoTemplate(), ["{content}", input.memo]);
         }
         
     }


### PR DESCRIPTION
The readme says,

> flags: like todo or task will add a bulletpoint. Example: task today do this

and it seems tokenizer can recognize a todo flag in their regexp part.
But there is no if-branch for the todo flag in the `writeInputToFile()`.

So I just copy and paste the task function with some modification. And also I add `tpl-todo` and `tpl-todo-after` configuration.

It worked on my environment (Ubuntu 16.04 LTS x64) but I'm not sure the modifications are good enough because I'm not familiar with vscode-extensions.

Hope this helps.