### PR TITLE
Fix for #36

### DIFF
--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -57,7 +57,7 @@ export class Configuration {
 
     public getLocale(): string {
         let locale: string | undefined = this.config.get<string>('locale');
-        return (isNullOrUndefined(locale) || (locale!.length === 0)) ? locale! : 'en-US';
+        return (isNullOrUndefined(locale) || (locale!.length === 0)) ? 'en-US' : locale!;
     }
 
 


### PR DESCRIPTION
Return value of `Configuration::getLocale()` in `conf.ts` is 'en-US' when valid(=not null, not undefined, and not zero-length) locale is set.
I think this PR will fix the problem.

Thank you.