### PR TITLE
add support for ${workspaceRoot} in base path

### DIFF
--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -135,8 +135,9 @@ export class Configuration {
             let base: string | undefined = this.config.get<string>('base');
 
             if (!isNullOrUndefined(base) && base!.length > 0) {
+                const workspaceRoot = vscode.workspace.workspaceFolders?.length && vscode.workspace.workspaceFolders[0].uri.fsPath || '';
                 // resolve homedir
-                base = base.replace("${homeDir}", os.homedir());
+                base = base.replace("${homeDir}", os.homedir()).replace("${workspaceRoot}", workspaceRoot);
                 base = Path.normalize(base);
                 return Path.format(Path.parse(base));
             } else {


### PR DESCRIPTION
In some cases, I want to create notes in current workspace, instead of a global dir.

Add handling of `${workspaceRoot}` in journal base path.