### PR TITLE
Command shortcuts for weekly journals

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
     "onCommand:journal.printDuration",
     "onCommand:journal.printTime",
     "onCommand:journal.printSum",
-    "onCommand:journal.test"
+    "onCommand:journal.test",
+    "onCommand:journal.current.week",
+    "onCommand:journal.next.week",
+    "onCommand:journal.previous.week"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -106,6 +109,21 @@
       {
         "command": "journal.open",
         "title": "Open the Journal",
+        "category": "Journal"
+      },
+      {
+        "command": "journal.current.week",
+        "title": "Open Current Week",
+        "category": "Journal"
+      },
+      {
+        "command": "journal.next.week",
+        "title": "Open Next Week",
+        "category": "Journal"
+      },
+      {
+        "command": "journal.previous.week",
+        "title": "Open Previous Week",
         "category": "Journal"
       }
     ],

--- a/src/actions/reader.ts
+++ b/src/actions/reader.ts
@@ -51,7 +51,7 @@ export class Reader {
      * Loads the weekly page for the given week number (of the year)
      * @param week the week of the current year
      */
-    public async loadEntryForWeek(week: Number): Promise<vscode.TextDocument> {
+    public async loadEntryForWeek(week: number): Promise<vscode.TextDocument> {
         return new Promise<vscode.TextDocument>((resolve, reject) => {
             this.ctrl.logger.trace("Entering loadEntryForWeek() in actions/reader.ts for week " + week);
 

--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -280,6 +280,10 @@ export class Configuration {
         });
     }
 
+    public getPatternDefinitions(): PatternDefinition {
+        return this.config.get<PatternDefinition>("patterns")!;
+    }
+
     getWeekFilePattern(week: Number, _scopeId?: string): any {
         return new Promise((resolve, reject) => {
             try {

--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -474,7 +474,7 @@ export class Configuration {
     private regExpDateFormats: RegExp = new RegExp(/\$\{(?:(year|month|day|localTime|localDate|weekday)|(d:[\s\S]+?))\}/g);
 
     private replaceDateFormats(template: string, date: Date): string {
-        let matches: RegExpMatchArray = template.match(this.regExpDateFormats) || [];
+        let matches = template.match(this.regExpDateFormats);
         // if (isNullOrUndefined(st.value)) { return st.template; }
 
         // console.log(JSON.stringify(matches));
@@ -482,7 +482,7 @@ export class Configuration {
         let mom: moment.Moment = moment(date);
         moment.locale(this.getLocale());
 
-        matches.forEach(match => {
+        matches?.forEach(match => {
             switch (match) {
                 case "${year}":
                     template = template.replace(match, mom.format("YYYY")); break;

--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -185,7 +185,7 @@ export class Configuration {
 
     public isSyntaxHighlightingEnabled(): boolean {
         let result = this.config.get<boolean>("syntax-highlighting");
-        return (isNullOrUndefined(result)) ? false : result!; 
+        return (isNullOrUndefined(result)) ? false : result!;
     }
 
     /**
@@ -201,7 +201,7 @@ export class Configuration {
         if (this.resolveScope(_scopeId) === SCOPE_DEFAULT) {
             result = this.config.get<PatternDefinition>("patterns")?.notes?.path;
         } else {
-            result = this.config.get<ScopeDefinition[]>("scopes")?.find(sd => sd.name === _scopeId)?.patterns?.notes?.path; 
+            result = this.config.get<ScopeDefinition[]>("scopes")?.find(sd => sd.name === _scopeId)?.patterns?.notes?.path;
         }
 
         if (isNullOrUndefined(result) || result!.length === 0) {
@@ -225,7 +225,7 @@ export class Configuration {
                     scope: (this.resolveScope(_scopeId) === SCOPE_DEFAULT) ? SCOPE_DEFAULT : _scopeId!,
                     template: this.getNotesPathPattern(_scopeId)!
                 };
-              
+
                 scopedTemplate.value = scopedTemplate.template;
 
                 // resolve variables
@@ -284,7 +284,7 @@ export class Configuration {
         return this.config.get<PatternDefinition>("patterns")!;
     }
 
-    getWeekFilePattern(week: Number, _scopeId?: string): any {
+    getWeekFilePattern(week: number, _scopeId?: string): any {
         return new Promise((resolve, reject) => {
             try {
                 let definition: string | undefined;
@@ -302,11 +302,13 @@ export class Configuration {
                 if (isNullOrUndefined(definition) || definition!.length === 0) {
                     definition = defaultPatternDefinition.notes.file;
                 }
+                let mom = moment();
+                mom.week(week);
+                mom.weekday(1);
 
                 scopedTemplate.value = definition!;
                 scopedTemplate.value = this.replaceVariableValue("ext", this.getFileExtension(), scopedTemplate.value);
-                scopedTemplate.value = this.replaceVariableValue("week", week + "", scopedTemplate.value);
-                scopedTemplate.value = this.replaceDateFormats(scopedTemplate.value, new Date());
+                scopedTemplate.value = this.replaceDateFormats(scopedTemplate.value, mom.toDate());
 
                 resolve(scopedTemplate);
             } catch (error) {

--- a/src/ext/startup.ts
+++ b/src/ext/startup.ts
@@ -127,7 +127,10 @@ export class Startup {
                 J.Provider.Commands.ShowEntryForYesterdayCommand.create(ctrl),
                 J.Provider.Commands.ShowNoteCommand.create(ctrl),
                 J.Provider.Commands.InsertMemoCommand.create(ctrl),
-                J.Provider.Commands.ShiftTaskCommand.create(ctrl)
+                J.Provider.Commands.ShiftTaskCommand.create(ctrl),
+                J.Provider.Commands.ShowEntryForCurrentWeekCommand.create(ctrl),
+                J.Provider.Commands.ShowEntryForNextWeekCommand.create(ctrl),
+                J.Provider.Commands.ShowEntryForPreviousWeekCommand.create(ctrl)
             );
 
         } catch (error) {

--- a/src/provider/commands/index.ts
+++ b/src/provider/commands/index.ts
@@ -9,3 +9,4 @@ export { ShowEntryForTomorrowCommand } from './show-entry-for-tomorrow';
 export { ShowEntryForYesterdayCommand } from './show-entry-for-yesterday';
 export { ShowNoteCommand } from './show-note';
 export { InsertMemoCommand } from './insert-memo';
+export { ShowEntryForCurrentWeekCommand, ShowEntryForNextWeekCommand, ShowEntryForPreviousWeekCommand } from './show-entry-for-week';

--- a/src/provider/commands/show-entry-for-week.ts
+++ b/src/provider/commands/show-entry-for-week.ts
@@ -1,0 +1,117 @@
+// Copyright (C) 2021  Patrick Maué
+// 
+// This file is part of vscode-journal.
+// 
+// vscode-journal is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// vscode-journal is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with vscode-journal.  If not, see <http://www.gnu.org/licenses/>.
+// 
+'use strict';
+
+import * as vscode from 'vscode';
+import * as J from '../..';
+import moment = require("moment");
+import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
+
+class AbstractShowEntryForWeekCommand extends AbstractLoadEntryForDateCommand {
+    protected constructor(public ctrl: J.Util.Ctrl, public offset: number) {
+        super(ctrl);
+    }
+
+    public override async execute(input: J.Model.Input): Promise<void> {
+        let editor: vscode.TextEditor = <vscode.TextEditor>vscode.window.activeTextEditor;
+        let currentWeek = moment().week();
+        if (this.offset !== 0) {
+            let filepattern = this.ctrl.config.getPatternDefinitions().weeks.file;
+            let filename = editor.document.fileName.split('/').pop()!;
+            let values = this.extractValueByPattern(filepattern, filename);
+            if (!isNaN(parseInt(values["week"]))) {
+                currentWeek = parseInt(values["week"]);
+            }
+            currentWeek += this.offset;
+        }
+        input.week = currentWeek;
+        super.execute(input);
+    }
+
+    /**
+     * Extracts values from a filename based on a given file pattern.
+     * 
+     * @param {string} filepattern - 'week_${week}.${ext}'.
+     * @param {string} filename -  'week_21.md'.
+     * @returns {Record<string, string>} - { week: "21", ext: "md" }
+     */
+    extractValueByPattern(filepattern: string, filename: string) {
+        const regexPattern = filepattern.replace(/\$\{(\w+)\}/g, '(?<$1>\\w+)');
+        const regex = new RegExp(regexPattern);
+
+        const match = filename.match(regex);
+        let extractedValues: Record<string, string> = {};
+        if (match) {
+            for (let group in match.groups) {
+                extractedValues[group] = match.groups[group];
+            }
+        }
+        return extractedValues;
+    }
+
+}
+
+export class ShowEntryForCurrentWeekCommand extends AbstractShowEntryForWeekCommand {
+    title: string = "Show journal entry for current week";
+    command: string = "journal.current.week";
+
+
+    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+        const cmd = new this(ctrl, 0);
+
+        let input = new J.Model.Input();
+
+        vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));
+        return cmd;
+    }
+
+}
+
+export class ShowEntryForNextWeekCommand extends AbstractShowEntryForWeekCommand {
+    title: string = "Show journal entry for next week";
+    command: string = "journal.next.week";
+
+
+    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+        const cmd = new this(ctrl, +1);
+
+        let input = new J.Model.Input();
+        input.week = 1;
+
+        vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));
+        return cmd;
+    }
+
+}
+
+export class ShowEntryForPreviousWeekCommand extends AbstractShowEntryForWeekCommand {
+    title: string = "Show journal entry for previous week";
+    command: string = "journal.previous.week";
+
+
+    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+        const cmd = new this(ctrl, -1);
+
+        let input = new J.Model.Input();
+        input.week = -1;
+
+        vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));
+        return cmd;
+    }
+
+}

--- a/src/provider/commands/show-entry-for-week.ts
+++ b/src/provider/commands/show-entry-for-week.ts
@@ -34,8 +34,11 @@ class AbstractShowEntryForWeekCommand extends AbstractLoadEntryForDateCommand {
             let filepattern = this.ctrl.config.getPatternDefinitions().weeks.file;
             let filename = editor.document.fileName.split('/').pop()!;
             let values = this.extractValueByPattern(filepattern, filename);
+            let filemoment = moment(filename.split('.')[0]);
             if (!isNaN(parseInt(values["week"]))) {
                 currentWeek = parseInt(values["week"]);
+            } else if (filemoment.isValid() && filemoment.weekday() === 1) {
+                currentWeek = filemoment.week();
             }
             currentWeek += this.offset;
         }
@@ -91,7 +94,6 @@ export class ShowEntryForNextWeekCommand extends AbstractShowEntryForWeekCommand
         const cmd = new this(ctrl, +1);
 
         let input = new J.Model.Input();
-        input.week = 1;
 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));
         return cmd;
@@ -108,7 +110,6 @@ export class ShowEntryForPreviousWeekCommand extends AbstractShowEntryForWeekCom
         const cmd = new this(ctrl, -1);
 
         let input = new J.Model.Input();
-        input.week = -1;
 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));
         return cmd;

--- a/src/test/direct/direct.ts
+++ b/src/test/direct/direct.ts
@@ -5,11 +5,11 @@ import { ScopedTemplate } from "../../model";
 
 let regExpDateFormats: RegExp = new RegExp(/\$\{(?:(year|month|day|localTime|localDate)|(d:\w+))\}/g);
 export function replaceDateFormats(st: ScopedTemplate, date: Date): void {
-    let matches: RegExpMatchArray = st.template.match(regExpDateFormats) || [];
+    let matches = st.template.match(regExpDateFormats);
 
     console.log(JSON.stringify(matches));
 
-    if (matches.length === 0) { return; }
+    if (matches === null || matches.length === 0) { return; }
 
     let mom: moment.Moment = moment(date);
 
@@ -60,4 +60,4 @@ let t2: ScopedTemplate = {
 };
 
 replaceDateFormats(t2, new Date());
-console.log(t2.template); 
+console.log(t2.template);

--- a/src/test/direct/path-parse-with-date.ts
+++ b/src/test/direct/path-parse-with-date.ts
@@ -122,8 +122,8 @@ export async function getDateFromURI(uri: string, pathTemplate: string, fileTemp
 
 
 export function replaceDateTemplatesWithMomentsFormats(template: string): string {
-    let matches: RegExpMatchArray = template.match(regExpDateFormats) || [];
-    matches.forEach(match => {
+    let matches = template.match(regExpDateFormats);
+    matches?.forEach(match => {
         switch (match) {
             case "${year}":
                 template = template.replace(match, "YYYY"); break;

--- a/src/util/dates.ts
+++ b/src/util/dates.ts
@@ -131,7 +131,7 @@ export function normalizeDayAsString(input: string, locale?: string): moment.Mom
     const regExpDateFormats: RegExp = new RegExp(/\$\{(?:(year|month|day|localTime|localDate|weekday)|(d:[\s\S]+?))\}/g);
 
     export function replaceDateFormats(template: string, date: Date, locale?: string): string {
-        let matches: RegExpMatchArray = template.match(regExpDateFormats) || [];
+        let matches = template.match(regExpDateFormats);
         // if (isNullOrUndefined(st.value)) { return st.template; }
 
         // console.log(JSON.stringify(matches));
@@ -139,7 +139,7 @@ export function normalizeDayAsString(input: string, locale?: string): moment.Mom
         let mom: moment.Moment = moment(date);
         moment.locale(locale);
 
-        matches.forEach(match => {
+        matches?.forEach(match => {
             switch (match) {
                 case "${year}":
                     template = template.replace(match, mom.format("YYYY")); break;
@@ -171,8 +171,8 @@ export function normalizeDayAsString(input: string, locale?: string): moment.Mom
     }
 
     export function replaceDateTemplatesWithMomentsFormats(template: string): string {
-        let matches: RegExpMatchArray = template.match(regExpDateFormats) || [];
-        matches.forEach(match => {
+        let matches = template.match(regExpDateFormats);
+        matches?.forEach(match => {
             switch (match) {
                 case "${year}":
                     template = template.replace(match, "YYYY"); break;


### PR DESCRIPTION
This is a small update to include three new commands that allow users to easily cycle through weekly journals. It checks the current document and if it is a weekly journal, it will open the next or previous week's journal accordingly.


<img width="630" alt="Screenshot 2024-05-26 at 5 11 57 PM" src="https://github.com/pajoma/vscode-journal/assets/2920178/337246be-9ff0-44a2-a06a-603a8047ff51">

