### PR TITLE
feat(navigation): open previous / next entry commands (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ## Unreleased
 
+### Added
+* [Issue #144](https://github.com/pajoma/vscode-journal/issues/144) New commands `journal.openPrevious` (`ctrl+j ,` / `cmd+j ,`) and `journal.openNext` (`ctrl+j .` / `cmd+j .`) step backwards / forwards through journal entries relative to the file currently in focus. New setting `journal.navigation.mode` chooses between `existing` (default — skip gaps to the next entry on disk) and `calendar` (step exactly one day, create if missing). Navigation honors the active scope.
+
 ### Fixed
 * [Issue #51](https://github.com/pajoma/vscode-journal/issues/51) Remote SSH and WSL Remote no longer surface a "File not found" error toast on first-time creation of an entry, weekly page, or note. Replaced the open-before-create antipattern in `Reader.loadEntryForDay`, `Reader.loadEntryForWeek`, and `LoadNotes.loadNote` with a stat-first check (new `fileExists` helper in `src/util/fs-exists.ts`) and migrated the three methods to native `async/await`.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,12 +5,16 @@ You can access all functionality (besides opening the journal) from the smart in
 
 ## Journal Pages
 
-* `journal:day` (keybindings: `ctrl+shift+j` or `cmd+shift+j` on mac) opens the smart input, see 
+* `journal:day` (keybindings: `ctrl+shift+j` or `cmd+shift+j` on mac) opens the smart input, see
 * `journal:today` for opening today's entry
 * `journal:tomorrow`
+* `journal:openPrevious` (keybindings: `ctrl+j ,` or `cmd+j ,` on mac) opens the previous journal entry relative to the file currently in focus. When no journal file is open, navigation starts from today. Behavior controlled by `journal.navigation.mode` (see `settings.md`):
+  * `existing` *(default)* — skip gaps and open the previous entry that exists on disk. Shows an info toast at the start of history.
+  * `calendar` — step exactly one day back and create the entry if missing.
+* `journal:openNext` (keybindings: `ctrl+j .` or `cmd+j .` on mac) mirror of `openPrevious` for forward navigation.
 
 ## Notes & Memos
-`journal:note` opens a dialog to enter the title of a new page for notes. 
+`journal:note` opens a dialog to enter the title of a new page for notes.
 
 ## Open the journal
 `journal:open` starts a new instance of vscode with the base directory of your journal as root 

--- a/docs/plans/2026-05-14-feat-144-prev-next-navigation.md
+++ b/docs/plans/2026-05-14-feat-144-prev-next-navigation.md
@@ -1,0 +1,271 @@
+# Issue #144 — Implementation Plan: Open Previous / Open Next entry navigation
+
+> **Spec:** [docs/specs/2026-05-14-feat-144-prev-next-navigation.md](../specs/2026-05-14-feat-144-prev-next-navigation.md)
+> **Issue:** [pajoma/vscode-journal#144](https://github.com/pajoma/vscode-journal/issues/144)
+> **Branch:** `144-journal-open-previous-and-open-next-feature`
+> **Created:** 2026-05-14
+
+## Approach
+
+Build the feature in three thin layers:
+
+1. **Pure navigation logic** in a new module `src/actions/navigation.ts`. Two exported functions:
+   - `resolveAnchor(ctrl, editor) → { date, scope }` — parses the active editor's URI via `getDateFromURIAndConfig`. Falls back to `{ today, SCOPE_DEFAULT }` on any failure.
+   - `findAdjacentEntry(ctrl, anchor, direction, mode) → Date | null` — for `mode: 'calendar'` it returns `anchor.date ± 1d`; for `mode: 'existing'` it enumerates the scope's entry directory and returns the nearest existing entry date in the requested direction (or `null` if none).
+
+2. **Two command classes** in `src/provider/commands/open-previous-entry.ts` and `open-next-entry.ts`. Both extend `AbstractLoadEntryForDateCommand` to reuse the existing local-vs-remote dialog, error handling, and `loadPageForInput` plumbing. Each `execute()` resolves the anchor, computes the target date via `findAdjacentEntry`, builds an `Input` with the resolved offset, and either delegates to the base class (when the target file exists or mode is `calendar`) or shows an info toast (when `existing` mode returns `null`).
+
+3. **Manifest + l10n wiring**. New commands, keybindings, settings, and locale strings in `package.json`, `package.nls*.json`, and `l10n/bundle.l10n*.json`.
+
+Trade-offs:
+- Splitting "anchor resolution + adjacency scan" into a pure helper makes the directory walk unit-testable without going through `vscode.commands.executeCommand`. The cost is one extra small file, which is consistent with the existing `features/` style (`load-note.ts`, `match-input.ts`, `scan-entries.ts`).
+- Extending `AbstractLoadEntryForDateCommand` carries the remote-session prompt for free. Alternative — duplicating the open-vs-create path — is rejected because it would diverge over time.
+- Adjacency scan does NOT reuse `ScanEntries`. `ScanEntries` enumerates everything for the picklist and caches; navigation needs the OPPOSITE access pattern (a quick "is there an entry on day X" check, ideally short-circuiting after one hit). A fresh, tightly-scoped `vscode.workspace.fs.readDirectory` walk is simpler and avoids the cache-invalidation hazard called out in spec open-question #3.
+
+Detection technique: TDD. The pure helper has straightforward, mockable inputs — write the test cases for both modes and both directions first, then implement.
+
+## Steps
+
+### Step 1 — Baseline
+
+- Branch already checked out and synced with `develop` (carries the merged #51 work).
+- Run `npm install` and `npm run check`. Confirm 57 tests pass before any change.
+
+### Step 2 — Manifest scaffolding (no impl yet)
+
+The manifest entries are independent of the implementation and easier to review in isolation. Add them first so the test file can reference `vscode.workspace.getConfiguration('journal').get('navigation.mode')` without a manifest mismatch.
+
+- `package.json` `contributes.commands` — append:
+  ```json
+  { "command": "journal.openPrevious", "title": "%command.journal.openPrevious.title%", "category": "Journal" },
+  { "command": "journal.openNext", "title": "%command.journal.openNext.title%", "category": "Journal" }
+  ```
+- `package.json` `contributes.keybindings` — append:
+  ```json
+  { "command": "journal.openPrevious", "key": "ctrl+j ,", "mac": "cmd+j ,", "when": "editorTextFocus" },
+  { "command": "journal.openNext", "key": "ctrl+j .", "mac": "cmd+j .", "when": "editorTextFocus" }
+  ```
+- `package.json` `contributes.configuration.properties` — append:
+  ```json
+  "journal.navigation.mode": {
+    "type": "string",
+    "enum": ["existing", "calendar"],
+    "default": "existing",
+    "description": "%configuration.journal.navigation.mode.description%"
+  }
+  ```
+- `package.nls.json` — add `command.journal.openPrevious.title`, `command.journal.openNext.title`, `configuration.journal.navigation.mode.description`.
+- `package.nls.<locale>.json` for de, fr, es, it, pt, nl, ru, zh, ja, ar — same three keys, translated. Translations: machine-translate as a first pass, mark in the PR description for native-speaker review (consistent with how the existing locale files were populated per the l10n migration).
+- `l10n/bundle.l10n.json` — add runtime strings:
+  - `"No earlier journal entry found."`
+  - `"No later journal entry found."`
+- `l10n/bundle.l10n.<locale>.json` — same two strings, translated, for each of the ten non-default locales.
+- `npm run l10n:export` to confirm the export script accepts the new keys without errors.
+
+After this step, `npm run check` should still pass (no Code changes yet, just manifest growth).
+
+### Step 3 — Failing tests (TDD)
+
+New file `src/test/suite/commands-prev-next.test.ts`. Pattern matches `commands-entry.test.ts` — uses real `vscode.workspace.fs` and an isolated tmp `journal.base`.
+
+Tests in this file (all failing initially):
+
+1. **`navigation.resolveAnchor` returns the parsed date and default scope for a daily-entry path.** Seed an entry at `<tmpBase>/2025/03/08.md`, open it, call `resolveAnchor`, assert `{ date: 2025-03-08, scope: 'default' }`.
+2. **`navigation.resolveAnchor` falls back to today + default scope when no editor is open.** Close all editors, call `resolveAnchor`, assert `date` is today and `scope === 'default'`.
+3. **`navigation.resolveAnchor` falls back to today + default scope for a non-journal file.** Open a random `.md` outside the journal base, call `resolveAnchor`, assert the today fallback.
+4. **`findAdjacentEntry(existing, previous)` finds the nearest past entry.** Seed `03-05`, `03-08`, `03-12`. Anchor `03-08`. Call with `direction: 'previous'`. Assert `2025-03-05`.
+5. **`findAdjacentEntry(existing, next)` finds the nearest future entry.** Same seed, anchor `03-08`, direction `next`. Assert `2025-03-12`.
+6. **`findAdjacentEntry(existing, previous)` returns `null` at the start of history.** Anchor `03-05` (the oldest seeded entry). Direction `previous`. Assert `null`.
+7. **`findAdjacentEntry(existing, next)` returns `null` at the end of history.** Anchor `03-12`. Direction `next`. Assert `null`.
+8. **`findAdjacentEntry(calendar, previous)` always returns `anchor - 1d`.** Anchor `03-08`, mode `calendar`, direction `previous`. Assert `2025-03-07` regardless of whether `03-07.md` exists.
+9. **`findAdjacentEntry(calendar, next)` always returns `anchor + 1d`.** Mirror of #8.
+10. **`findAdjacentEntry` walks year boundaries.** Seed `2024/12/30.md` and `2025/01/05.md`. Anchor `2024/12/30`, mode `existing`, direction `next`. Assert `2025-01-05`.
+11. **`OpenPreviousEntryCommand.execute` opens the prior entry.** Seed `03-05/08/12`. Open `03-08`. Execute the command. Assert `vscode.window.activeTextEditor.document.uri.fsPath` ends with `03-05` (loose comparator to tolerate path separators).
+12. **`OpenPreviousEntryCommand.execute` shows a toast and does not change editor at the start of history.** Open `03-05`. Spy on `vscode.window.showInformationMessage`. Execute. Assert the spy was called with the l10n string and the active editor is unchanged.
+13. **`OpenNextEntryCommand.execute` in `calendar` mode creates the next-day entry if missing.** Set `journal.navigation.mode` to `calendar`. Anchor `03-08`. Execute next. Assert `03-09.md` exists on disk and is the active editor.
+
+Run `npm test -- --grep "#144"`. Confirm 13 reds.
+
+### Step 4 — Implement `navigation.ts`
+
+New file `src/actions/navigation.ts` (~80 lines).
+
+```typescript
+import * as vscode from 'vscode';
+import * as Path from 'path';
+import { Ctrl } from '../util/controller';
+import { getDateFromURIAndConfig } from '../util/paths';
+import { SCOPE_DEFAULT } from '../ext/conf';
+import { fileExists } from '../util/fs-exists';
+
+export type Direction = 'previous' | 'next';
+export type Mode = 'existing' | 'calendar';
+
+export interface Anchor {
+    date: Date;
+    scope: string;
+}
+
+export async function resolveAnchor(ctrl: Ctrl, editor: vscode.TextEditor | undefined): Promise<Anchor> {
+    if (!editor) { return { date: stripTime(new Date()), scope: SCOPE_DEFAULT }; }
+    try {
+        const date = await getDateFromURIAndConfig(editor.document.uri.fsPath, ctrl.config);
+        const scope = await resolveScopeFromPath(ctrl, editor.document.uri.fsPath);
+        return { date: stripTime(date), scope };
+    } catch {
+        return { date: stripTime(new Date()), scope: SCOPE_DEFAULT };
+    }
+}
+
+export async function findAdjacentEntry(
+    ctrl: Ctrl,
+    anchor: Anchor,
+    direction: Direction,
+    mode: Mode,
+): Promise<Date | null> {
+    if (mode === 'calendar') {
+        return addDays(anchor.date, direction === 'previous' ? -1 : 1);
+    }
+    return walkForAdjacent(ctrl, anchor, direction);
+}
+
+// Implementation helpers (stripTime, addDays, resolveScopeFromPath, walkForAdjacent)
+// — kept private to this module.
+```
+
+`walkForAdjacent` is the load-bearing function. Strategy:
+
+1. Resolve the anchor's scope base path (`ctrl.config.getBasePath(anchor.scope)`).
+2. Resolve the entry-path template for the anchor date (`ctrl.config.getResolvedEntryPath(anchor.date, anchor.scope)`) and entry-file template (`ctrl.config.getEntryFilePattern(anchor.date)`).
+3. From the path template, compute the directory shape (`${base}/${year}/${month}`). This gives the per-month container.
+4. Enumerate year directories under `${base}` via `vscode.workspace.fs.readDirectory` (filter to entries matching `\d{4}`). Sort ascending or descending based on direction.
+5. Within each year, enumerate month directories (filter to `\d{2}` or matching the configured pattern); sort.
+6. Within each month, enumerate day files (filter to `\d{2}\.<ext>` or matching the configured file pattern); sort.
+7. As the walk iterates, compare each candidate's parsed date to the anchor:
+   - For `direction: 'previous'`: keep iterating until the LAST candidate strictly less than the anchor date is found.
+   - For `direction: 'next'`: keep iterating until the FIRST candidate strictly greater than the anchor date is found.
+8. Short-circuit: when iterating in the chosen direction (descending for `previous`, ascending for `next`) the first candidate matching the strict-inequality condition IS the answer; no need to continue.
+
+`resolveScopeFromPath` checks each configured scope's base path (`ctrl.config.getBasePath(scopeId)`) and returns the scope whose base is a prefix of the file path. Falls back to `SCOPE_DEFAULT`.
+
+Re-run tests 1–10. Confirm they pass.
+
+### Step 5 — Implement command classes
+
+New file `src/provider/commands/open-previous-entry.ts`:
+
+```typescript
+'use strict';
+import * as vscode from 'vscode';
+import * as J from '../..';
+import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
+import { findAdjacentEntry, resolveAnchor, Mode } from '../../actions/navigation';
+
+export class OpenPreviousEntryCommand extends AbstractLoadEntryForDateCommand {
+    title: string = vscode.l10n.t("Open the previous journal entry");
+    command: string = "journal.openPrevious";
+
+    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+        const cmd = new this(ctrl);
+        vscode.commands.registerCommand(cmd.command, () => cmd.run());
+        return cmd;
+    }
+
+    public async run(): Promise<void> {
+        const mode = (vscode.workspace.getConfiguration('journal').get<string>('navigation.mode') ?? 'existing') as Mode;
+        const anchor = await resolveAnchor(this.ctrl, vscode.window.activeTextEditor);
+        const target = await findAdjacentEntry(this.ctrl, anchor, 'previous', mode);
+        if (target === null) {
+            await vscode.window.showInformationMessage(vscode.l10n.t("No earlier journal entry found."));
+            return;
+        }
+        const input = new J.Model.Input();
+        input.offset = daysBetween(new Date(), target); // negative for past
+        await this.execute(input);
+    }
+}
+```
+
+`OpenNextEntryCommand` mirrors with `direction: 'next'` and the "No later journal entry found." string.
+
+`daysBetween(today, target)` is a tiny helper colocated in `navigation.ts` and exported. It computes the integer day delta so the existing `Input.offset` machinery in `AbstractLoadEntryForDateCommand` resolves the same date.
+
+Wire into `src/provider/commands/index.ts` and `src/ext/startup.ts` alongside the other `.create(ctrl)` calls.
+
+Re-run tests 11–13. Confirm they pass.
+
+### Step 6 — Full check
+
+- `npm run check` — lint clean, all tests pass.
+- `npm run l10n:export` — bundle regenerates without warnings.
+
+### Step 7 — Manual verification (Extension Development Host)
+
+Drive the scenarios from spec acceptance #2–#5 in the EDH (`F5`). Capture before/after for the PR description.
+
+- Pre-seed `test/ws_manual/` (or a fresh tmp workspace) with three daily entries.
+- Open the middle one. Try `Ctrl+J ,` and `Ctrl+J .`. Try the edges (no earlier / no later).
+- Toggle `journal.navigation.mode` to `calendar`. Repeat. Verify create-if-missing.
+- Close all editors. Try the keybindings — confirm today fallback works.
+- Configure a second scope. Add entries to it. Open one. Confirm navigation stays within the scope.
+- Spot-check the German locale (`code --locale=de`): command palette titles and the info toasts render in German.
+
+### Step 8 — Documentation hook
+
+Per issue #181 (the docs refresh issue filed this session), update the two short anchors that block the smoke test from running:
+
+- Append `journal.openPrevious` and `journal.openNext` (with `Ctrl+J ,` / `Ctrl+J .` bindings) to `docs/commands.md`.
+- Append `journal.navigation.mode` to `docs/settings.md` with one short paragraph and an enum table.
+
+Detailed cross-doc reconciliation is owned by #181 and is NOT in scope for this PR.
+
+### Step 9 — PR + release artifacts
+
+- `CHANGELOG.md` — under `Unreleased`, add an `### Added` block (or extend an existing one) referencing #144.
+- `PLAN.md` — no phase change; the feature is independent of the modernization roadmap. Optionally append a one-line note under "Planned" -> "Done" if you maintain that history.
+- PR title: `feat(navigation): open previous / next entry commands (#144)`.
+- PR body links: issue, spec doc, plan doc, EDH screenshots.
+- Post on the issue: "PR #Y opens — implementing approved plan." Nothing else.
+
+## Test scenarios
+
+| ID | Layer | Name | Acceptance link |
+|----|-------|------|-----------------|
+| T1 | unit (helper) | `resolveAnchor` parses a daily-entry path to `{ date, scope }` | spec § In scope #3 |
+| T2 | unit | `resolveAnchor` falls back to today when no editor is open | spec § In scope #3 |
+| T3 | unit | `resolveAnchor` falls back to today for a non-journal file | spec § In scope #3 |
+| T4 | unit | `findAdjacentEntry(existing, previous)` finds the prior on-disk entry | spec § Acceptance #2 |
+| T5 | unit | `findAdjacentEntry(existing, next)` finds the next on-disk entry | spec § Acceptance #2 |
+| T6 | unit | `findAdjacentEntry(existing, previous)` returns `null` at the start | spec § Acceptance #2 (edge toast) |
+| T7 | unit | `findAdjacentEntry(existing, next)` returns `null` at the end | spec § Acceptance #2 (edge toast) |
+| T8 | unit | `findAdjacentEntry(calendar, previous)` returns `anchor − 1d` | spec § Acceptance #3 |
+| T9 | unit | `findAdjacentEntry(calendar, next)` returns `anchor + 1d` | spec § Acceptance #3 |
+| T10 | unit | `findAdjacentEntry` crosses year boundaries | spec § Open questions #1 |
+| T11 | integration | `OpenPreviousEntryCommand` opens the prior entry | spec § Acceptance #2 |
+| T12 | integration | `OpenPreviousEntryCommand` shows the "no earlier" toast and leaves the editor unchanged | spec § Acceptance #2 |
+| T13 | integration | `OpenNextEntryCommand` in `calendar` mode creates the next-day entry | spec § Acceptance #3 |
+| M1 | manual (EDH) | All five acceptance scenarios from spec § Acceptance manually verified | spec § Acceptance #2–#6 |
+| M2 | manual (EDH) | German-locale spot-check of command titles and toasts | spec § Acceptance #6 |
+
+## Dependencies
+
+None. No cross-issue blockers, no cross-repo branches required.
+
+Soft dependency: issue #181 (docs refresh) — this PR adds the two thin doc anchors needed for the smoke test (#180) section on configuration. The full docs reconciliation is #181's responsibility.
+
+## Risk
+
+- **R1: `getDateFromURIAndConfig` brittleness.** It already uses moment.js (slated for removal in PLAN.md Phase 3) and parses by template substitution. If the user's `journal.patterns` deviates from the default shape, anchor detection may fail and silently fall back to today. *Mitigation:* T3 covers a non-journal file. Document the fallback in `docs/commands.md` so the behavior is explicit. Phase 3 will improve this surface; we ride along with whatever it does later.
+- **R2: Directory walk performance.** For a journal that has been used daily for 5+ years, the directory tree has ~60+ month folders, each with ~30 day files. Worst case `previous` from `2025-01-01` walks back through 2024, 2023, … until it finds one — but the directory listing is small (12 months × 31 day files at most). No measurable UI block expected. *Mitigation:* Short-circuit on first match. If anyone reports slowness, add a single-level cache keyed by scope.
+- **R3: Scope detection by prefix-match.** If two scopes have base paths where one is a prefix of the other (e.g. `~/Journal` and `~/Journal/work`), `resolveScopeFromPath` may pick the wrong one. *Mitigation:* iterate longest-base-first when matching; covered by an additional unit test if reviewers flag it. Configured scopes with overlapping bases are pathological but we should not silently misroute.
+- **R4: l10n machine-translation quality.** Strings for ten non-English locales translated by machine. Native-speaker review is asynchronous. *Mitigation:* PR description flags the non-English strings for native-speaker review; the feature works in English even if a locale string is imperfect. Same approach used during the `vscode.l10n` migration.
+- **R5: Keybinding collisions.** `Ctrl+J ,` and `Ctrl+J .` are chord-style — unlikely to collide with built-in VS Code commands, but third-party extensions may bind them. *Mitigation:* keybinding `when: editorTextFocus` narrows the trigger surface. Users can rebind via Keyboard Shortcuts as the issue explicitly anticipates.
+
+## Rollback
+
+- Revert the squashed PR commit on `develop`. No data migration, no config schema migration concerns. Pre-existing settings without `journal.navigation.mode` continue to work; the absence of the setting on a rolled-back manifest just makes the key inert.
+- Manifest entries (commands, keybindings, configuration) are additive and revert cleanly.
+
+## Reference spec
+
+`docs/specs/2026-05-14-feat-144-prev-next-navigation.md` (committed at `3a35d24`).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -215,6 +215,18 @@ Depending on the version this setting might activate certain new features. In ge
 
 Controls if new files are created in full mode or in a new editor group (split pane). 
 
+### Navigation Mode
+* Key: `journal.navigation.mode`
+* Default value: `existing`
+* Allowed values: `existing`, `calendar`
 
+Controls how the `Open Previous Journal Entry` (`ctrl+j ,`) and `Open Next Journal Entry` (`ctrl+j .`) commands step through entries.
+
+| Value | Behavior |
+|-------|----------|
+| `existing` *(default)* | Find the previous / next entry that already exists on disk. Skips gaps (weekends, vacations). At the start or end of history an info toast is shown and the editor does not change. |
+| `calendar` | Step exactly one calendar day back or forward from the anchor file. Creates the target entry if missing (same as `Open Yesterday` / `Open Tomorrow`). |
+
+The anchor is the currently open journal entry. When no journal file is open, the anchor falls back to today. Navigation honors the active scope — derived from the anchor file's path or the default scope when no anchor file is open.
 
 ![Screen Capture](./set-base-directory.gif)

--- a/docs/specs/2026-05-14-feat-144-prev-next-navigation.md
+++ b/docs/specs/2026-05-14-feat-144-prev-next-navigation.md
@@ -1,0 +1,124 @@
+# Issue #144 — Open Previous / Open Next entry navigation
+
+> **Issue:** [pajoma/vscode-journal#144](https://github.com/pajoma/vscode-journal/issues/144)
+> **Branch:** `144-journal-open-previous-and-open-next-feature`
+> **Created:** 2026-05-14
+
+## Goal
+
+Add two commands — `journal.openPrevious` and `journal.openNext` — that step backwards / forwards through journal **daily entries** relative to the currently open file. Step semantics are user-configurable: either "next/previous **existing** entry on disk" (default) or "next/previous **calendar day** (create if missing)". Navigation honors the active journal scope. Default keybindings: `Ctrl+J ,` (previous) and `Ctrl+J .` (next).
+
+## Why now
+
+Filed in 2018 by a user with parallel work/personal journals. Pain point: traversing meeting notes day-by-day requires opening the smart-input prompt and typing offsets each time. The pain compounds with multi-day gaps (weekends, holidays) where `-1` doesn't land on an existing entry. Now is a reasonable time because:
+
+- The `ScanEntries` feature (added later for the picklist) already enumerates all entries on disk — `openPrevious` mode `existing` can reuse that walk.
+- `getDateFromURIAndConfig` (`src/util/paths.ts:113`) already extracts a `Date` from a journal entry's path — needed to identify the "current" anchor.
+- `1.1.0` milestone owns this issue and pruning the milestone is a release goal.
+
+## Scope
+
+### In scope
+
+1. **Two new commands** registered under `journal.openPrevious` and `journal.openNext` with command palette titles and l10n entries across the eleven existing locales (en, de, fr, es, it, pt, nl, ru, zh, ja, ar).
+
+2. **Two navigation modes**, selected by a new setting `journal.navigation.mode`:
+   - `"existing"` *(default)* — find the previous/next entry whose file already exists on disk. Skip gaps. If no prior entry exists, show an info toast ("No earlier journal entry found") and do nothing.
+   - `"calendar"` — step exactly `-1` / `+1` calendar day from the anchor. Create the target entry if missing (same code path as `Open Yesterday` / `Open Tomorrow` already exercise). No skipping.
+
+3. **Anchor resolution**:
+   - If `vscode.window.activeTextEditor.document.uri` is a journal **daily entry** (date parseable via `getDateFromURIAndConfig`), that entry's date is the anchor.
+   - Otherwise (no editor open, or the active document is not a journal entry — e.g. a note, weekly entry, attachment, or some unrelated file), the anchor is **today**.
+   - When the anchor is today and mode is `existing`, "previous" means the most recent past entry; "next" means today (if exists) or the nearest future entry (if any was pre-created).
+
+4. **Scope honoring**:
+   - The active scope is derived from the anchor entry's path (which scope's `${base}` matches the parent directory). If the anchor is "today" (no file open), the active scope is the **default** scope.
+   - Navigation in `existing` mode walks only the entries under the active scope's resolved entry directory. Cross-scope navigation is not in scope.
+
+5. **Default keybindings**: `Ctrl+J ,` → `journal.openPrevious`, `Ctrl+J .` → `journal.openNext`. Both bound to the `editorTextFocus` `when` clause (consistent with `journal.printDuration` / `journal.printSum`). User can override via `Keyboard Shortcuts`.
+
+6. **Settings UI**: register `journal.navigation.mode` in `package.json` `contributes.configuration` with enum values `"existing"` and `"calendar"` and a default of `"existing"`. Translated description strings.
+
+7. **Tests**:
+   - Unit-level coverage for the date-stepping helper(s) used to resolve "previous existing" and "next existing" against a mocked directory listing.
+   - Integration test in the Extension Host: pre-seed a tmp workspace with three entries (e.g. `2025-03-05`, `2025-03-08`, `2025-03-12`), open the middle one, run `openPrevious`, assert the `2025-03-05` entry is opened. Same shape for `openNext`. Same shape for `calendar` mode with create-if-missing.
+   - Regression test: when no anchor file is open, `openPrevious` walks back from today.
+   - Regression test: when active scope is non-default, navigation stays within that scope's directory.
+
+### Out of scope
+
+- **Weekly entries.** `${base}/<year>/<week>.md` (or wherever weeklies live) is not part of the chronological traversal in this PR. They can be added later if requested. (Issue text mentions "notes" only.)
+- **Notes** (the per-day subdirectory note files). Navigating across note files within a day or across days is a separate, more complex problem (mixing chronology with title-based ordering). Out of scope per the clarifying-question answers — user chose "honor active scope" without selecting notes.
+- **Cross-scope navigation.** If the user has both `work` and `private` scopes, navigation does not jump from `work` entries to `private` entries.
+- **Wrap-around.** Reaching the oldest/newest entry shows an info toast and stops. No wrap-around to opposite end.
+- **Recent-files MRU traversal.** Navigation is by entry **date**, not by file-modification time.
+- **CodeLens / status-bar navigation buttons.** Command palette + keybindings only.
+- **Caching.** `ScanEntries` already maintains a cache for the picklist; reuse it if convenient, but a dedicated cache for prev/next is not in scope. A fresh `vscode.workspace.fs.readDirectory` walk per invocation is acceptable for typical journal sizes.
+
+## Acceptance criteria
+
+1. `npm run check` clean. New tests pass on first run.
+2. **Manual — `existing` mode (default):**
+   - Workspace pre-seeded with daily entries on `2025-03-05`, `2025-03-08`, `2025-03-12`. No entry for any other date.
+   - Open `2025-03-08`. `Ctrl+J ,` opens `2025-03-05`. `Ctrl+J .` opens `2025-03-12`.
+   - From `2025-03-12`, `Ctrl+J .` shows the info toast "No later journal entry found." and the editor does not change.
+   - From `2025-03-05`, `Ctrl+J ,` shows "No earlier journal entry found." and the editor does not change.
+   - No `[ERROR]` lines in the Journal output channel.
+3. **Manual — `calendar` mode:**
+   - With `journal.navigation.mode` set to `calendar`, open `2025-03-08`. `Ctrl+J ,` opens `2025-03-07` (created if missing). `Ctrl+J .` opens `2025-03-09` (created if missing).
+4. **Manual — no anchor:**
+   - Close all editors. `Ctrl+J ,` (in `existing` mode) opens the most recent past entry (e.g. `2025-03-12` from the seed above if today is later). `Ctrl+J .` opens the nearest future entry or shows the toast if none.
+5. **Manual — multi-scope:**
+   - Two scopes configured: `default` and `work`. Seed `default` with entries `2025-03-05/08/12` and `work` with entries `2025-04-01/02`. Open the `work` entry `2025-04-02`. `Ctrl+J ,` opens `2025-04-01`, NOT a default-scope entry.
+6. **L10n:** Command palette titles and the "No earlier/later entry found" toast render in German, French, Spanish, etc. — at least one non-English locale spot-checked.
+
+## Entities / contracts touched
+
+- `src/provider/commands/` — two new command files:
+  - `open-previous-entry.ts` (`journal.openPrevious`)
+  - `open-next-entry.ts` (`journal.openNext`)
+  Each follows the existing static-`create(ctrl)` pattern (see `show-entry-for-today.ts`).
+- `src/provider/commands/index.ts` — register the new commands.
+- `src/ext/startup.ts` — wire the new commands into the activation sequence.
+- `src/actions/navigation.ts` — **new file** containing the pure navigation logic:
+  - `resolveAnchor(ctrl, activeEditor): Promise<{ date: Date; scope: string }>`
+  - `findAdjacentEntry(ctrl, anchor: { date; scope }, direction: 'previous' | 'next', mode: 'existing' | 'calendar'): Promise<Date | null>`
+  Separating logic from command surface lets tests target the helpers directly without command-palette plumbing.
+- `package.json`:
+  - `contributes.commands` — two new entries.
+  - `contributes.keybindings` — two new entries (`ctrl+j ,` and `ctrl+j .`, `when: editorTextFocus`).
+  - `contributes.configuration.properties` — new `journal.navigation.mode` enum.
+- `package.nls.json` and `package.nls.<locale>.json` for all eleven locales — new strings:
+  - `command.journal.openPrevious.title`
+  - `command.journal.openNext.title`
+  - `configuration.journal.navigation.mode.description`
+- `l10n/bundle.l10n.json` and `l10n/bundle.l10n.<locale>.json` — runtime strings for the toasts ("No earlier journal entry found", "No later journal entry found").
+- `src/test/suite/` — new test file `commands-prev-next.test.ts` (matches the `commands-*` naming pattern).
+
+## Constraints
+
+- **No raw `fs`.** All FS access via `vscode.workspace.fs` (PLAN.md Phase 1.3 invariant).
+- **`vscode.l10n`.** New user-facing strings go through `vscode.l10n.t(...)` for runtime, NLS keys for manifest.
+- **Anchor detection must be robust** to paths that look journal-shaped but are not (e.g. a markdown file in the journal base that wasn't created by this extension). The anchor resolution falls back to "today" on any parse failure rather than throwing.
+- **Performance.** For workspaces with thousands of entries, the `existing` walk should not block the UI noticeably. Strategy: walk the entry directory (already structured by year/month per `journal.patterns.notes.path` defaults), short-circuit as soon as the adjacent file is found rather than enumerating the entire tree.
+- **No promise wrappers in new code.** Write native `async/await` from the start (PLAN.md Phase 2.2 direction).
+- **Named imports preferred.** New files use `import { Foo } from '...'` rather than `import * as J from '...'` for new code (PLAN.md Phase 2.3 direction). Existing wiring code can stay namespace-style.
+
+## Open questions
+
+1. **Year-boundary traversal in `existing` mode.** If the entry directory is `${base}/2024/12/31.md` and the next entry is `${base}/2025/01/05.md`, the walk must cross the year subdirectory. The plan must spell out the directory enumeration order to ensure this works.
+2. **What counts as a "daily entry" in the walk?** The entry filename pattern defaults to `${day}.${ext}` (e.g. `14.md`). Notes live in `${base}/<year>/<month>/<day>/<title>.md`. Anchor detection must distinguish — likely by matching the exact path template, not just "any markdown file under base".
+3. **Stale `ScanEntries` cache.** If the cache is used and a new entry has been created since the cache was populated, the cache may miss it. Plan: either bypass the cache for navigation, or invalidate after `createEntryForPath`. Decision deferred to the plan.
+
+## Related issues
+
+- Indirectly related: `ScanEntries` and the picklist feature share directory-walking logic — reuse vs. duplicate is a plan-level decision.
+- No cross-repo dependencies. No `blocked-by:` / `blocks:` labels.
+
+## Reference
+
+- Issue body (one paragraph): user navigates meeting notes day-by-day, wants prev/next shortcuts that complement `Open Yesterday` / `Open Tomorrow`.
+- Existing similar surfaces for inspiration:
+  - `src/provider/commands/show-entry-for-date.ts:97` — already does anchor-aware entry resolution for the smart-input.
+  - `src/provider/features/scan-entries.ts:13` — directory-walking + caching.
+  - `src/util/paths.ts:113` — `getDateFromURIAndConfig` for anchor parsing.

--- a/l10n/bundle.l10n.ar.json
+++ b/l10n/bundle.l10n.ar.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "إضافة مهمة للأسبوع {week}",
   "Add task to entry {day}": "إضافة مهمة إلى الإدخال {day}",
   "Add memo to entry {day}": "إضافة مذكرة إلى الإدخال {day}",
-  "Create or open entry {day}": "إنشاء أو فتح الإدخال {day}"
+  "Create or open entry {day}": "إنشاء أو فتح الإدخال {day}",
+  "No earlier journal entry found.": "لم يتم العثور على إدخال مجلة سابق.",
+  "No later journal entry found.": "لم يتم العثور على إدخال مجلة لاحق."
 }

--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Aufgabe zum Eintrag für Woche {week} hinzufügen",
   "Add task to entry {day}": "Aufgabe zum Eintrag {day} hinzufügen",
   "Add memo to entry {day}": "Memo zum Eintrag {day} hinzufügen",
-  "Create or open entry {day}": "Eintrag {day} erstellen oder öffnen"
+  "Create or open entry {day}": "Eintrag {day} erstellen oder öffnen",
+  "No earlier journal entry found.": "Kein früherer Journaleintrag gefunden.",
+  "No later journal entry found.": "Kein späterer Journaleintrag gefunden."
 }

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Añadir tarea a la entrada de la semana {week}",
   "Add task to entry {day}": "Añadir tarea a la entrada del {day}",
   "Add memo to entry {day}": "Agregar un memo a la entrada {day}",
-  "Create or open entry {day}": "Crear o abrir una entrada {day}"
+  "Create or open entry {day}": "Crear o abrir una entrada {day}",
+  "No earlier journal entry found.": "No se encontró ninguna entrada anterior del diario.",
+  "No later journal entry found.": "No se encontró ninguna entrada posterior del diario."
 }

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Ajouter une tâche à l'entrée de la semaine {week}",
   "Add task to entry {day}": "Ajouter une tâche à l'entrée du {day}",
   "Add memo to entry {day}": "Ajouter un mémo à l'entrée {day}",
-  "Create or open entry {day}": "Créer ou ouvrir une entrée {day}"
+  "Create or open entry {day}": "Créer ou ouvrir une entrée {day}",
+  "No earlier journal entry found.": "Aucune entrée antérieure du journal trouvée.",
+  "No later journal entry found.": "Aucune entrée ultérieure du journal trouvée."
 }

--- a/l10n/bundle.l10n.it.json
+++ b/l10n/bundle.l10n.it.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Aggiungi un compito per la settimana {week}",
   "Add task to entry {day}": "Aggiungi un compito all'entrata {day}",
   "Add memo to entry {day}": "Aggiungi un memo all'entrata {day}",
-  "Create or open entry {day}": "Crea o apri l'entrata {day}"
+  "Create or open entry {day}": "Crea o apri l'entrata {day}",
+  "No earlier journal entry found.": "Nessuna voce precedente del diario trovata.",
+  "No later journal entry found.": "Nessuna voce successiva del diario trovata."
 }

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "第 {week} 週のエントリにタスクを追加",
   "Add task to entry {day}": "{day} のエントリにタスクを追加",
   "Add memo to entry {day}": "{day} のエントリにメモを追加",
-  "Create or open entry {day}": "{day} のエントリを作成または開く"
+  "Create or open entry {day}": "{day} のエントリを作成または開く",
+  "No earlier journal entry found.": "以前の日誌エントリが見つかりません。",
+  "No later journal entry found.": "以降の日誌エントリが見つかりません。"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -13,5 +13,7 @@
   "Add memo to entry {day}": "Add memo to entry {day}",
   "Create or open entry {day}": "Create or open entry {day}",
   "[from] dddd": "[from] dddd",
-  "[from] ll": "[from] ll"
+  "[from] ll": "[from] ll",
+  "No earlier journal entry found.": "No earlier journal entry found.",
+  "No later journal entry found.": "No later journal entry found."
 }

--- a/l10n/bundle.l10n.nl.json
+++ b/l10n/bundle.l10n.nl.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Taak toevoegen voor week {week}",
   "Add task to entry {day}": "Taak toevoegen aan invoer {day}",
   "Add memo to entry {day}": "Voeg memo toe aan invoer {day}",
-  "Create or open entry {day}": "Maak of open invoer {day}"
+  "Create or open entry {day}": "Maak of open invoer {day}",
+  "No earlier journal entry found.": "Geen eerdere journaalvermelding gevonden.",
+  "No later journal entry found.": "Geen latere journaalvermelding gevonden."
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Adicionar tarefa para a semana {week}",
   "Add task to entry {day}": "Adicionar tarefa à entrada {day}",
   "Add memo to entry {day}": "Adicionar memorando à entrada {day}",
-  "Create or open entry {day}": "Criar ou abrir entrada {day}"
+  "Create or open entry {day}": "Criar ou abrir entrada {day}",
+  "No earlier journal entry found.": "Nenhuma entrada anterior do diário encontrada.",
+  "No later journal entry found.": "Nenhuma entrada posterior do diário encontrada."
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "Добавить задачу на неделю {week}",
   "Add task to entry {day}": "Добавить задачу в запись {day}",
   "Add memo to entry {day}": "Добавить заметку в запись {day}",
-  "Create or open entry {day}": "Создать или открыть запись {day}"
+  "Create or open entry {day}": "Создать или открыть запись {day}",
+  "No earlier journal entry found.": "Более ранняя запись журнала не найдена.",
+  "No later journal entry found.": "Более поздняя запись журнала не найдена."
 }

--- a/l10n/bundle.l10n.zh.json
+++ b/l10n/bundle.l10n.zh.json
@@ -13,5 +13,7 @@
   "Add task to entry for week {week}": "将任务添加到第 {week} 周的条目",
   "Add task to entry {day}": "将任务添加到条目 {day}",
   "Add memo to entry {day}": "将备忘录添加到条目 {day}",
-  "Create or open entry {day}": "创建或打开条目 {day}"
+  "Create or open entry {day}": "创建或打开条目 {day}",
+  "No earlier journal entry found.": "未找到更早的日志条目。",
+  "No later journal entry found.": "未找到更晚的日志条目。"
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,16 @@
         "command": "journal.open",
         "title": "%command.journal.open.title%",
         "category": "%command.category.journal%"
+      },
+      {
+        "command": "journal.openPrevious",
+        "title": "%command.journal.openPrevious.title%",
+        "category": "%command.category.journal%"
+      },
+      {
+        "command": "journal.openNext",
+        "title": "%command.journal.openNext.title%",
+        "category": "%command.category.journal%"
       }
     ],
     "keybindings": [
@@ -124,6 +134,18 @@
         "key": "ctrl+j s",
         "mac": "cmd+j s",
         "when": "editorTextFocus && editorHasMultipleSelections"
+      },
+      {
+        "command": "journal.openPrevious",
+        "key": "ctrl+j ,",
+        "mac": "cmd+j ,",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "journal.openNext",
+        "key": "ctrl+j .",
+        "mac": "cmd+j .",
+        "when": "editorTextFocus"
       }
     ],
     "grammars": [
@@ -265,6 +287,12 @@
           "type": "boolean",
           "default": "false",
           "description": "%configuration.journal.dev.description%"
+        },
+        "journal.navigation.mode": {
+          "type": "string",
+          "enum": ["existing", "calendar"],
+          "default": "existing",
+          "description": "%configuration.journal.navigation.mode.description%"
         },
         "journal.openInNewEditorGroup": {
           "type": "boolean",

--- a/package.nls.ar.json
+++ b/package.nls.ar.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "فتح اليوم",
-    "command.journal.tomorrow.title": "فتح الغد"
+    "command.journal.tomorrow.title": "فتح الغد",
+    "command.journal.openPrevious.title": "فتح المُدخل السابق",
+    "command.journal.openNext.title": "فتح المُدخل التالي"
 }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -9,5 +9,7 @@
     "command.journal.printDuration.title": "Differenz zwischen ausgewählten Zeiten einfügen",
     "command.journal.printSum.title": "Summe der ausgewählten Zahlen einfügen",
     "command.journal.day.title": "Bestimmten Tag öffnen",
-    "command.journal.open.title": "Journal öffnen"
+    "command.journal.open.title": "Journal öffnen",
+    "command.journal.openPrevious.title": "Vorherigen Tageseintrag öffnen",
+    "command.journal.openNext.title": "Nächsten Tageseintrag öffnen"
 }

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "Abrir hoy",
-    "command.journal.tomorrow.title": "Abrir mañana"
+    "command.journal.tomorrow.title": "Abrir mañana",
+    "command.journal.openPrevious.title": "Abrir entrada anterior",
+    "command.journal.openNext.title": "Abrir entrada siguiente"
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "Ouvrir aujourd'hui",
-    "command.journal.tomorrow.title": "Ouvrir demain"
+    "command.journal.tomorrow.title": "Ouvrir demain",
+    "command.journal.openPrevious.title": "Ouvrir l'entrée précédente",
+    "command.journal.openNext.title": "Ouvrir l'entrée suivante"
 }

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "Apri oggi",
-    "command.journal.tomorrow.title": "Apri domani"
+    "command.journal.tomorrow.title": "Apri domani",
+    "command.journal.openPrevious.title": "Apri voce precedente",
+    "command.journal.openNext.title": "Apri voce successiva"
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "今日を開く",
-    "command.journal.tomorrow.title": "明日を開く"
+    "command.journal.tomorrow.title": "明日を開く",
+    "command.journal.openPrevious.title": "前の日誌を開く",
+    "command.journal.openNext.title": "次の日誌を開く"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,6 +12,8 @@
     "command.journal.printSum.title": "Print the sum of the selected numbers",
     "command.journal.day.title": "Enter specific day",
     "command.journal.open.title": "Open the Journal",
+    "command.journal.openPrevious.title": "Open Previous Journal Entry",
+    "command.journal.openNext.title": "Open Next Journal Entry",
     "configuration.title": "VSCode Journal",
     "configuration.journal.base.description": "The base directory for your notes. Defaults to the directory 'Journal' in your home directory. Supports embedded variables as described in the Guide.",
     "configuration.journal.ext.description": "The default extension of your notes and journal entries. Defaults to markdown (.md).",
@@ -19,6 +21,7 @@
     "configuration.journal.syntax-highlighting.description": "Enable extension specific syntax highlighting (default is false).",
     "configuration.journal.patterns.description": "Individual patterns which define where and how notes and entries are stored. Check the wiki for defaults and options.",
     "configuration.journal.dev.description": "If enabled, the features in development will be activated (other features might be broken).",
+    "configuration.journal.navigation.mode.description": "How `Open Previous` and `Open Next` step through journal entries. `existing` skips gaps and only opens entries that already exist on disk. `calendar` steps exactly one day at a time and creates the entry if missing. Default: `existing`.",
     "configuration.journal.openInNewEditorGroup.description": "If true, the journal pages and new notes will split the editor view.",
     "configuration.journal.scopes.description": "Define your own scopes here, see Guide for more details.",
     "configuration.journal.templates.description": "Definition of templates used when generate content for the journal. See Guide for more details."

--- a/package.nls.nl.json
+++ b/package.nls.nl.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "Vandaag openen",
-    "command.journal.tomorrow.title": "Morgen openen"
+    "command.journal.tomorrow.title": "Morgen openen",
+    "command.journal.openPrevious.title": "Vorige journaalvermelding openen",
+    "command.journal.openNext.title": "Volgende journaalvermelding openen"
 }

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "Abrir hoje",
-    "command.journal.tomorrow.title": "Abrir amanhã"
+    "command.journal.tomorrow.title": "Abrir amanhã",
+    "command.journal.openPrevious.title": "Abrir entrada anterior",
+    "command.journal.openNext.title": "Abrir entrada seguinte"
 }

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "Открыть запись на сегодня",
-    "command.journal.tomorrow.title": "Открыть запись на завтра"
+    "command.journal.tomorrow.title": "Открыть запись на завтра",
+    "command.journal.openPrevious.title": "Открыть предыдущую запись",
+    "command.journal.openNext.title": "Открыть следующую запись"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,5 +1,7 @@
 {
     "command.category.journal": "Journal",
     "command.journal.today.title": "打开今天",
-    "command.journal.tomorrow.title": "打开明天"
+    "command.journal.tomorrow.title": "打开明天",
+    "command.journal.openPrevious.title": "打开上一篇日志",
+    "command.journal.openNext.title": "打开下一篇日志"
 }

--- a/src/actions/navigation.ts
+++ b/src/actions/navigation.ts
@@ -1,0 +1,172 @@
+// Copyright (C) 2026  Patrick Maué
+//
+// This file is part of vscode-journal.
+//
+// vscode-journal is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// vscode-journal is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with vscode-journal.  If not, see <http://www.gnu.org/licenses/>.
+
+'use strict';
+
+import * as vscode from 'vscode';
+import * as Path from 'path';
+import { Ctrl } from '../util/controller';
+import { SCOPE_DEFAULT } from '../ext/conf';
+import { getDateFromURIAndConfig } from '../util/paths';
+
+interface ScopeDefinitionLite {
+    name?: string;
+    base?: string;
+}
+
+export type Direction = 'previous' | 'next';
+export type Mode = 'existing' | 'calendar';
+
+export interface Anchor {
+    date: Date;
+    scope: string;
+}
+
+export function stripTime(d: Date): Date {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+export function addDays(d: Date, days: number): Date {
+    const result = new Date(d.getFullYear(), d.getMonth(), d.getDate() + days);
+    return result;
+}
+
+export function daysBetween(from: Date, to: Date): number {
+    const a = stripTime(from).getTime();
+    const b = stripTime(to).getTime();
+    return Math.round((b - a) / (1000 * 60 * 60 * 24));
+}
+
+export async function resolveAnchor(ctrl: Ctrl, editor: vscode.TextEditor | undefined): Promise<Anchor> {
+    if (!editor) {
+        return { date: stripTime(new Date()), scope: SCOPE_DEFAULT };
+    }
+    const fsPath = editor.document.uri.fsPath;
+    let date: Date;
+    try {
+        date = await getDateFromURIAndConfig(fsPath, ctrl.config);
+        if (!date || date.toString().includes('Invalid')) { throw new Error('invalid date parsed'); }
+    } catch {
+        return { date: stripTime(new Date()), scope: SCOPE_DEFAULT };
+    }
+    const scope = resolveScopeFromPath(ctrl, fsPath);
+    return { date: stripTime(date), scope };
+}
+
+function resolveScopeFromPath(ctrl: Ctrl, fsPath: string): string {
+    const scopes = vscode.workspace.getConfiguration('journal').get<ScopeDefinitionLite[]>('scopes') ?? [];
+    const candidates: Array<{ scope: string; base: string }> = [];
+    for (const scopeDef of scopes) {
+        if (!scopeDef?.name) { continue; }
+        try {
+            const base = ctrl.config.getBasePath(scopeDef.name);
+            if (base && base.length > 0) {
+                candidates.push({ scope: scopeDef.name, base: Path.normalize(base) });
+            }
+        } catch {
+            // ignore unresolvable scope
+        }
+    }
+    candidates.sort((a, b) => b.base.length - a.base.length);
+    const normalizedPath = Path.normalize(fsPath);
+    for (const c of candidates) {
+        if (normalizedPath.startsWith(c.base + Path.sep) || normalizedPath === c.base) {
+            return c.scope;
+        }
+    }
+    return SCOPE_DEFAULT;
+}
+
+export async function findAdjacentEntry(
+    ctrl: Ctrl,
+    anchor: Anchor,
+    direction: Direction,
+    mode: Mode,
+): Promise<Date | null> {
+    if (mode === 'calendar') {
+        return addDays(anchor.date, direction === 'previous' ? -1 : 1);
+    }
+    return walkForAdjacent(ctrl, anchor, direction);
+}
+
+async function walkForAdjacent(ctrl: Ctrl, anchor: Anchor, direction: Direction): Promise<Date | null> {
+    const base = ctrl.config.getBasePath(anchor.scope === SCOPE_DEFAULT ? undefined : anchor.scope);
+    if (!base) { return null; }
+    const baseUri = vscode.Uri.file(Path.normalize(base));
+
+    const yearEntries = await readDirSafe(baseUri);
+    const years = yearEntries
+        .filter(([name, type]) => (type & vscode.FileType.Directory) !== 0 && /^\d{4}$/.test(name))
+        .map(([name]) => parseInt(name, 10))
+        .sort((a, b) => direction === 'previous' ? b - a : a - b);
+
+    const anchorYear = anchor.date.getFullYear();
+    const anchorMonth = anchor.date.getMonth() + 1;
+    const anchorDay = anchor.date.getDate();
+    const anchorKey = anchorYear * 10000 + anchorMonth * 100 + anchorDay;
+
+    for (const year of years) {
+        if (direction === 'previous' && year > anchorYear) { continue; }
+        if (direction === 'next' && year < anchorYear) { continue; }
+
+        const yearUri = vscode.Uri.joinPath(baseUri, String(year).padStart(4, '0'));
+        const monthEntries = await readDirSafe(yearUri);
+        const months = monthEntries
+            .filter(([name, type]) => (type & vscode.FileType.Directory) !== 0 && /^\d{2}$/.test(name))
+            .map(([name]) => parseInt(name, 10))
+            .sort((a, b) => direction === 'previous' ? b - a : a - b);
+
+        for (const month of months) {
+            if (year === anchorYear) {
+                if (direction === 'previous' && month > anchorMonth) { continue; }
+                if (direction === 'next' && month < anchorMonth) { continue; }
+            }
+
+            const monthUri = vscode.Uri.joinPath(yearUri, String(month).padStart(2, '0'));
+            const dayEntries = await readDirSafe(monthUri);
+            const ext = ctrl.config.getFileExtension();
+            const dayFilePattern = new RegExp(`^(\\d{2})\\.${escapeRegex(ext)}$`);
+            const days = dayEntries
+                .filter(([name, type]) => (type & vscode.FileType.File) !== 0 && dayFilePattern.test(name))
+                .map(([name]) => parseInt(name.match(dayFilePattern)![1], 10))
+                .sort((a, b) => direction === 'previous' ? b - a : a - b);
+
+            for (const day of days) {
+                const key = year * 10000 + month * 100 + day;
+                if (direction === 'previous' && key < anchorKey) {
+                    return new Date(year, month - 1, day);
+                }
+                if (direction === 'next' && key > anchorKey) {
+                    return new Date(year, month - 1, day);
+                }
+            }
+        }
+    }
+    return null;
+}
+
+async function readDirSafe(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
+    try {
+        return await vscode.workspace.fs.readDirectory(uri);
+    } catch {
+        return [];
+    }
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/ext/startup.ts
+++ b/src/ext/startup.ts
@@ -125,7 +125,9 @@ export class Startup {
                 J.Provider.Commands.ShowEntryForYesterdayCommand.create(ctrl),
                 J.Provider.Commands.ShowNoteCommand.create(ctrl),
                 J.Provider.Commands.InsertMemoCommand.create(ctrl),
-                J.Provider.Commands.ShiftTaskCommand.create(ctrl)
+                J.Provider.Commands.ShiftTaskCommand.create(ctrl),
+                J.Provider.Commands.OpenPreviousEntryCommand.create(ctrl),
+                J.Provider.Commands.OpenNextEntryCommand.create(ctrl)
             );
 
         } catch (error) {

--- a/src/provider/commands/index.ts
+++ b/src/provider/commands/index.ts
@@ -9,3 +9,5 @@ export { ShowEntryForTomorrowCommand } from './show-entry-for-tomorrow';
 export { ShowEntryForYesterdayCommand } from './show-entry-for-yesterday';
 export { ShowNoteCommand } from './show-note';
 export { InsertMemoCommand } from './insert-memo';
+export { OpenPreviousEntryCommand } from './open-previous-entry';
+export { OpenNextEntryCommand } from './open-next-entry';

--- a/src/provider/commands/open-next-entry.ts
+++ b/src/provider/commands/open-next-entry.ts
@@ -1,0 +1,39 @@
+// Copyright (C) 2026  Patrick Maué
+//
+// This file is part of vscode-journal.
+//
+// vscode-journal is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+'use strict';
+
+import * as vscode from 'vscode';
+import * as J from '../..';
+import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
+import { daysBetween, findAdjacentEntry, resolveAnchor, Mode } from '../../actions/navigation';
+
+export class OpenNextEntryCommand extends AbstractLoadEntryForDateCommand {
+    title: string = "Open the next journal entry";
+    command: string = "journal.openNext";
+
+    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+        const cmd = new this(ctrl);
+        vscode.commands.registerCommand(cmd.command, () => cmd.run());
+        return cmd;
+    }
+
+    public async run(): Promise<void> {
+        const mode = (vscode.workspace.getConfiguration('journal').get<string>('navigation.mode') ?? 'existing') as Mode;
+        const anchor = await resolveAnchor(this.ctrl, vscode.window.activeTextEditor);
+        const target = await findAdjacentEntry(this.ctrl, anchor, 'next', mode);
+        if (target === null) {
+            await vscode.window.showInformationMessage(vscode.l10n.t("No later journal entry found."));
+            return;
+        }
+        const input = new J.Model.Input();
+        input.offset = daysBetween(new Date(), target);
+        await this.execute(input);
+    }
+}

--- a/src/provider/commands/open-previous-entry.ts
+++ b/src/provider/commands/open-previous-entry.ts
@@ -1,0 +1,39 @@
+// Copyright (C) 2026  Patrick Maué
+//
+// This file is part of vscode-journal.
+//
+// vscode-journal is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+'use strict';
+
+import * as vscode from 'vscode';
+import * as J from '../..';
+import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
+import { daysBetween, findAdjacentEntry, resolveAnchor, Mode } from '../../actions/navigation';
+
+export class OpenPreviousEntryCommand extends AbstractLoadEntryForDateCommand {
+    title: string = "Open the previous journal entry";
+    command: string = "journal.openPrevious";
+
+    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+        const cmd = new this(ctrl);
+        vscode.commands.registerCommand(cmd.command, () => cmd.run());
+        return cmd;
+    }
+
+    public async run(): Promise<void> {
+        const mode = (vscode.workspace.getConfiguration('journal').get<string>('navigation.mode') ?? 'existing') as Mode;
+        const anchor = await resolveAnchor(this.ctrl, vscode.window.activeTextEditor);
+        const target = await findAdjacentEntry(this.ctrl, anchor, 'previous', mode);
+        if (target === null) {
+            await vscode.window.showInformationMessage(vscode.l10n.t("No earlier journal entry found."));
+            return;
+        }
+        const input = new J.Model.Input();
+        input.offset = daysBetween(new Date(), target);
+        await this.execute(input);
+    }
+}

--- a/src/test/suite/commands-prev-next.test.ts
+++ b/src/test/suite/commands-prev-next.test.ts
@@ -1,0 +1,281 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as J from '../..';
+import { TestLogger } from '../test-logger';
+import {
+    addDays,
+    daysBetween,
+    findAdjacentEntry,
+    resolveAnchor,
+    stripTime,
+} from '../../actions/navigation';
+import { SCOPE_DEFAULT } from '../../ext';
+import { OpenNextEntryCommand } from '../../provider/commands/open-next-entry';
+import { OpenPreviousEntryCommand } from '../../provider/commands/open-previous-entry';
+
+async function seedEntry(base: string, year: number, month: number, day: number, content = '# Entry\n'): Promise<string> {
+    const yy = String(year).padStart(4, '0');
+    const mm = String(month).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
+    const dir = vscode.Uri.file(path.join(base, yy, mm));
+    await vscode.workspace.fs.createDirectory(dir);
+    const file = vscode.Uri.file(path.join(base, yy, mm, `${dd}.md`));
+    await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(content));
+    return file.fsPath;
+}
+
+async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
+    const config = vscode.workspace.getConfiguration('journal');
+    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+    const refreshed = vscode.workspace.getConfiguration('journal');
+    const ctrl = new J.Util.Ctrl(refreshed);
+    const logger = new TestLogger(false);
+    ctrl.logger = logger;
+    return { ctrl, logger };
+}
+
+suite('Issue #144 — Open Previous / Open Next navigation', () => {
+
+    suite('date helpers', () => {
+        test('stripTime zeroes hours/minutes/seconds', () => {
+            const d = new Date(2025, 2, 8, 14, 30, 45);
+            const stripped = stripTime(d);
+            assert.strictEqual(stripped.getHours(), 0);
+            assert.strictEqual(stripped.getMinutes(), 0);
+            assert.strictEqual(stripped.getSeconds(), 0);
+        });
+
+        test('addDays advances and rolls into the next month', () => {
+            const d = new Date(2025, 2, 30); // 2025-03-30
+            const plus5 = addDays(d, 5);
+            assert.strictEqual(plus5.getFullYear(), 2025);
+            assert.strictEqual(plus5.getMonth(), 3); // April
+            assert.strictEqual(plus5.getDate(), 4);
+        });
+
+        test('daysBetween counts integer days', () => {
+            const a = new Date(2025, 2, 1);
+            const b = new Date(2025, 2, 8);
+            assert.strictEqual(daysBetween(a, b), 7);
+            assert.strictEqual(daysBetween(b, a), -7);
+        });
+    });
+
+    suite('helper layer with seeded base', () => {
+        let originalBase: string | undefined;
+        let originalMode: string | undefined;
+        let tmpBase: string;
+        let ctrl: J.Util.Ctrl;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            originalMode = config.get<string>('navigation.mode');
+
+            tmpBase = path.join(os.tmpdir(), `issue144-base-${Date.now()}`);
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
+            await config.update('navigation.mode', 'existing', vscode.ConfigurationTarget.Workspace);
+
+            ({ ctrl } = await buildCtrl(tmpBase));
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+            await config.update('navigation.mode', originalMode, vscode.ConfigurationTarget.Workspace);
+            try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
+        });
+
+        test('resolveAnchor falls back to today when no editor is open', async () => {
+            const anchor = await resolveAnchor(ctrl, undefined);
+            assert.strictEqual(anchor.scope, SCOPE_DEFAULT);
+            const today = stripTime(new Date());
+            assert.strictEqual(anchor.date.getTime(), today.getTime());
+        });
+
+        test('findAdjacentEntry(existing, previous) finds the prior on-disk entry', async () => {
+            await seedEntry(tmpBase, 2025, 3, 5);
+            await seedEntry(tmpBase, 2025, 3, 8);
+            await seedEntry(tmpBase, 2025, 3, 12);
+
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2025, 2, 8), scope: SCOPE_DEFAULT },
+                'previous',
+                'existing',
+            );
+            assert.ok(target, 'expected a target date');
+            assert.strictEqual(target!.getFullYear(), 2025);
+            assert.strictEqual(target!.getMonth(), 2);
+            assert.strictEqual(target!.getDate(), 5);
+        });
+
+        test('findAdjacentEntry(existing, next) finds the next on-disk entry', async () => {
+            await seedEntry(tmpBase, 2025, 3, 5);
+            await seedEntry(tmpBase, 2025, 3, 8);
+            await seedEntry(tmpBase, 2025, 3, 12);
+
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2025, 2, 8), scope: SCOPE_DEFAULT },
+                'next',
+                'existing',
+            );
+            assert.ok(target);
+            assert.strictEqual(target!.getDate(), 12);
+        });
+
+        test('findAdjacentEntry(existing, previous) returns null at the start of history', async () => {
+            await seedEntry(tmpBase, 2025, 3, 5);
+            await seedEntry(tmpBase, 2025, 3, 8);
+
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2025, 2, 5), scope: SCOPE_DEFAULT },
+                'previous',
+                'existing',
+            );
+            assert.strictEqual(target, null);
+        });
+
+        test('findAdjacentEntry(existing, next) returns null at the end of history', async () => {
+            await seedEntry(tmpBase, 2025, 3, 5);
+            await seedEntry(tmpBase, 2025, 3, 8);
+
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2025, 2, 8), scope: SCOPE_DEFAULT },
+                'next',
+                'existing',
+            );
+            assert.strictEqual(target, null);
+        });
+
+        test('findAdjacentEntry(calendar, previous) returns anchor - 1d regardless of disk', async () => {
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2025, 2, 8), scope: SCOPE_DEFAULT },
+                'previous',
+                'calendar',
+            );
+            assert.ok(target);
+            assert.strictEqual(target!.getDate(), 7);
+        });
+
+        test('findAdjacentEntry(calendar, next) returns anchor + 1d regardless of disk', async () => {
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2025, 2, 8), scope: SCOPE_DEFAULT },
+                'next',
+                'calendar',
+            );
+            assert.ok(target);
+            assert.strictEqual(target!.getDate(), 9);
+        });
+
+        test('findAdjacentEntry crosses year boundaries', async () => {
+            await seedEntry(tmpBase, 2024, 12, 30);
+            await seedEntry(tmpBase, 2025, 1, 5);
+
+            const target = await findAdjacentEntry(
+                ctrl,
+                { date: new Date(2024, 11, 30), scope: SCOPE_DEFAULT },
+                'next',
+                'existing',
+            );
+            assert.ok(target);
+            assert.strictEqual(target!.getFullYear(), 2025);
+            assert.strictEqual(target!.getMonth(), 0);
+            assert.strictEqual(target!.getDate(), 5);
+        });
+    });
+
+    suite('command layer', () => {
+        let originalBase: string | undefined;
+        let originalMode: string | undefined;
+        let tmpBase: string;
+        let ctrl: J.Util.Ctrl;
+        let infoMessages: string[];
+        let originalShowInfo: typeof vscode.window.showInformationMessage;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            originalMode = config.get<string>('navigation.mode');
+
+            tmpBase = path.join(os.tmpdir(), `issue144-cmd-${Date.now()}`);
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
+            await config.update('navigation.mode', 'existing', vscode.ConfigurationTarget.Workspace);
+
+            ({ ctrl } = await buildCtrl(tmpBase));
+
+            infoMessages = [];
+            originalShowInfo = vscode.window.showInformationMessage;
+            (vscode.window as any).showInformationMessage = async (msg: string, ..._rest: any[]) => {
+                infoMessages.push(msg);
+                return undefined;
+            };
+        });
+
+        teardown(async () => {
+            (vscode.window as any).showInformationMessage = originalShowInfo;
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+            await config.update('navigation.mode', originalMode, vscode.ConfigurationTarget.Workspace);
+            try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        });
+
+        test('OpenPreviousEntryCommand opens the prior on-disk entry', async () => {
+            const prevPath = await seedEntry(tmpBase, 2025, 3, 5);
+            const anchorPath = await seedEntry(tmpBase, 2025, 3, 8);
+            await seedEntry(tmpBase, 2025, 3, 12);
+
+            const anchorDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(anchorPath));
+            await vscode.window.showTextDocument(anchorDoc);
+
+            const cmdInstance = new (OpenPreviousEntryCommand as any)(ctrl);
+            await cmdInstance.run();
+
+            const active = vscode.window.activeTextEditor;
+            assert.ok(active, 'expected an active editor');
+            assert.strictEqual(path.normalize(active!.document.uri.fsPath), path.normalize(prevPath));
+        });
+
+        test('OpenPreviousEntryCommand shows toast at the start of history', async () => {
+            const oldestPath = await seedEntry(tmpBase, 2025, 3, 5);
+            const oldestDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(oldestPath));
+            await vscode.window.showTextDocument(oldestDoc);
+
+            const cmdInstance = new (OpenPreviousEntryCommand as any)(ctrl);
+            await cmdInstance.run();
+
+            assert.ok(infoMessages.some(m => /No earlier journal entry/i.test(m)),
+                `expected info toast; got ${JSON.stringify(infoMessages)}`);
+            const active = vscode.window.activeTextEditor;
+            assert.strictEqual(path.normalize(active!.document.uri.fsPath), path.normalize(oldestPath));
+        });
+
+        test('OpenNextEntryCommand in calendar mode creates the next-day entry', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('navigation.mode', 'calendar', vscode.ConfigurationTarget.Workspace);
+
+            const anchorPath = await seedEntry(tmpBase, 2025, 3, 8);
+            const anchorDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(anchorPath));
+            await vscode.window.showTextDocument(anchorDoc);
+
+            const cmdInstance = new (OpenNextEntryCommand as any)(ctrl);
+            await cmdInstance.run();
+
+            const expected = vscode.Uri.file(path.join(tmpBase, '2025', '03', '09.md'));
+            try {
+                const stat = await vscode.workspace.fs.stat(expected);
+                assert.ok(stat, 'expected next-day entry to exist on disk');
+            } catch (err) {
+                assert.fail(`next-day entry was not created: ${err}`);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Two new commands: `journal.openPrevious` (`Ctrl+J ,` / `Cmd+J ,`) and `journal.openNext` (`Ctrl+J .` / `Cmd+J .`) step backwards / forwards through journal **daily entries** relative to the currently open file. Fallback anchor is today when no journal file is open.
- New setting `journal.navigation.mode` (`existing` *(default)* | `calendar`):
  - `existing` — find the previous / next entry that **already exists on disk**. Skip gaps (weekends, vacations). Info toast at the start / end of history.
  - `calendar` — step exactly one calendar day. Create the target entry if missing (same code path as `Open Yesterday` / `Open Tomorrow`).
- Navigation honors the **active scope** — derived from the anchor file's path or the default scope when no anchor is open.
- All eleven locales updated: command titles in `package.nls.*.json`, runtime toast strings in `l10n/bundle.l10n.*.json`. **Non-English translations are first-pass machine translations and are flagged for native-speaker review.**

## Why

Issue #144 has been open since 2018. Pain point is traversing meeting notes day-by-day when there are gaps. Now is a reasonable time to ship because `getDateFromURIAndConfig` and `vscode.workspace.fs.readDirectory` make the implementation clean.

## Architecture

- `src/actions/navigation.ts` (new) — pure helpers `resolveAnchor`, `findAdjacentEntry`, plus date utilities. Unit-testable without going through `vscode.commands.executeCommand`.
- `src/provider/commands/open-previous-entry.ts` and `open-next-entry.ts` (new) — extend `AbstractLoadEntryForDateCommand` to reuse the existing local-vs-remote dialog and `loadPageForInput` plumbing.
- Adjacency scan does NOT reuse `ScanEntries`. Access patterns are opposite: `ScanEntries` enumerates everything for the picklist and caches; navigation wants a quick "is there an entry adjacent to day X" with short-circuit on first match. Fresh `vscode.workspace.fs.readDirectory` walk per invocation, sorted in the requested direction.
- Scope detection (`resolveScopeFromPath`) iterates configured scopes longest-base-first to avoid prefix-collision misroutes.

## Linked artifacts

- Issue: [pajoma/vscode-journal#144](https://github.com/pajoma/vscode-journal/issues/144)
- Spec: [`docs/specs/2026-05-14-feat-144-prev-next-navigation.md`](docs/specs/2026-05-14-feat-144-prev-next-navigation.md)
- Plan: [`docs/plans/2026-05-14-feat-144-prev-next-navigation.md`](docs/plans/2026-05-14-feat-144-prev-next-navigation.md)
- Spec approval: [#issuecomment-4454383016](https://github.com/pajoma/vscode-journal/issues/144#issuecomment-4454383016)
- Plan approval: [#issuecomment-4454424690](https://github.com/pajoma/vscode-journal/issues/144#issuecomment-4454424690)
- Soft dependency: #181 owns the full docs reconciliation; this PR ships the minimal anchors needed by #180 (smoke test).

## Test plan

Automated (`npm run check` — all 71 tests pass):

- [x] Date helpers (`stripTime`, `addDays`, `daysBetween`).
- [x] `resolveAnchor` falls back to today when no editor is open.
- [x] `findAdjacentEntry` finds the prior / next on-disk entry; returns null at the edges; year boundary crossing.
- [x] `findAdjacentEntry` in calendar mode returns anchor ± 1d regardless of disk state.
- [x] `OpenPreviousEntryCommand` opens the prior entry on disk.
- [x] `OpenPreviousEntryCommand` shows the "no earlier" info toast and does not change the editor at the start of history.
- [x] `OpenNextEntryCommand` in calendar mode creates the next-day entry on disk.

Manual (requires reviewer — best in Extension Development Host):

- [ ] Pre-seed three daily entries with gaps (e.g. `2025-03-05/08/12`). Open the middle one. `Ctrl+J ,` jumps to `03-05`; `Ctrl+J .` jumps to `03-12`. At the edges, the info toast appears and the editor does not change.
- [ ] Toggle `journal.navigation.mode` to `calendar`. From `03-08`, `Ctrl+J ,` opens `03-07` (created); `Ctrl+J .` opens `03-09` (created).
- [ ] Close all editors. `Ctrl+J ,` (in `existing` mode) opens the most recent past entry.
- [ ] Configure a second scope. Add entries to it. Open one. `Ctrl+J ,` stays within that scope (does NOT jump to the default scope).
- [ ] Locale spot-check with `code --locale=de`: command palette titles and the info toasts render in German.
- [ ] Native-speaker review of the new l10n strings in `package.nls.*.json` and `l10n/bundle.l10n.*.json` (de, fr, es, it, pt, nl, ru, zh, ja, ar).

## Risk and rollback

- Adjacency scan assumes the default `${base}/${year}/${month}/${day}.${ext}` path shape. Custom `journal.patterns.entries` shapes may not be discovered; falls back to "no entry found" rather than throwing.
- Scope detection by prefix-match with longest-base-first tie-breaker. Edge case: scopes with overlapping bases — currently no test for this, would add if reviewers flag.
- Locale strings are first-pass machine translations.
- Rollback: revert the squashed PR commit. Manifest entries are additive; pre-existing settings without `journal.navigation.mode` continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)