### PR TITLE
docs(changelog): record #167 weekly template name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [Issue #144](https://github.com/pajoma/vscode-journal/issues/144) New commands `journal.openPrevious` (`ctrl+j ,` / `cmd+j ,`) and `journal.openNext` (`ctrl+j .` / `cmd+j .`) step backwards / forwards through journal entries relative to the file currently in focus. New setting `journal.navigation.mode` chooses between `existing` (default — skip gaps to the next entry on disk) and `calendar` (step exactly one day, create if missing). Navigation honors the active scope.
 
 ### Fixed
+* [Issue #167](https://github.com/pajoma/vscode-journal/issues/167) Customizing the weekly entry template via `journal.templates` now takes effect. `Configuration.getWeeklyTemplate()` previously looked up the template under the id `"week"` while the default in `package.json` was registered as `"weekly"`, so user overrides were silently ignored. Aligned the lookup key with the default name (`"weekly"`). Regression test in `src/test/suite/phase1-regression.test.ts`.
 * [Issue #51](https://github.com/pajoma/vscode-journal/issues/51) Remote SSH and WSL Remote no longer surface a "File not found" error toast on first-time creation of an entry, weekly page, or note. Replaced the open-before-create antipattern in `Reader.loadEntryForDay`, `Reader.loadEntryForWeek`, and `LoadNotes.loadNote` with a stat-first check (new `fileExists` helper in `src/util/fs-exists.ts`) and migrated the three methods to native `async/await`.
 
 ### Changed


### PR DESCRIPTION
## Summary

The fix for [#167](https://github.com/pajoma/vscode-journal/issues/167) (weekly entry template ignored user overrides because `Configuration.getWeeklyTemplate()` looked up the template under the id `"week"` while `package.json` registered the default as `"weekly"`) landed earlier as part of Phase 1.1 of the modernization plan, along with a regression test in `src/test/suite/phase1-regression.test.ts`. The user-facing CHANGELOG was never updated.

This PR is documentation-only — it adds one bullet under `## Unreleased / ### Fixed` describing the fix, so the change is announced when the next version ships. Verified the existing regression test still passes:

```
Phase 1 — Regression Tests
  ✔ #167 — getWeeklyTemplate resolves the "weekly" template from config
1 passing (148ms)
```

Closes #167.

## Test plan

- [x] `npm test -- --grep "#167"` passes
- [x] CHANGELOG entry placed under `## Unreleased` → `### Fixed` next to #51, before the existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)