### PR TITLE
feat: entry granularity (weekly mode) + weekly daily-link auto-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Unreleased
 
 ### Added
+* [Issue #168](https://github.com/pajoma/vscode-journal/issues/168) New setting `journal.entryGranularity` (`daily` default, `weekly` alternative) routes memos, tasks, and new notes into the current week's entry / weekly notes folder when no explicit date target is given. Explicit date input (offset, ISO date, weekday, week number) still wins. Default `weekly` template now includes `## Tasks` and `## Notes` sections; new `journal.patterns.weeklyNotes` default (`${base}/${year}/w${week}`) controls the weekly notes path.
 * [Issue #144](https://github.com/pajoma/vscode-journal/issues/144) New commands `journal.openPrevious` (`ctrl+j ,` / `cmd+j ,`) and `journal.openNext` (`ctrl+j .` / `cmd+j .`) step backwards / forwards through journal entries relative to the file currently in focus. New setting `journal.navigation.mode` chooses between `existing` (default — skip gaps to the next entry on disk) and `calendar` (step exactly one day, create if missing). Navigation honors the active scope.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Unreleased
 
 ### Added
+* [Issue #185](https://github.com/pajoma/vscode-journal/issues/185) Weekly entries now auto-sync a list of links to all daily entries in the same ISO week, kept up to date while the weekly file is the active editor. New `journal.weeklySync` setting block (`enabled`, `anchor`, `template`, `sortOrder`) controls the behavior. Default `weekly` template ships with a `## Daily Entries` heading; user-customized templates without the anchor are skipped silently. Daily files are never modified — sync is one-directional.
 * [Issue #168](https://github.com/pajoma/vscode-journal/issues/168) New setting `journal.entryGranularity` (`daily` default, `weekly` alternative) routes memos, tasks, and new notes into the current week's entry / weekly notes folder when no explicit date target is given. Explicit date input (offset, ISO date, weekday, week number) still wins. Default `weekly` template now includes `## Tasks` and `## Notes` sections; new `journal.patterns.weeklyNotes` default (`${base}/${year}/w${week}`) controls the weekly notes path.
 * [Issue #144](https://github.com/pajoma/vscode-journal/issues/144) New commands `journal.openPrevious` (`ctrl+j ,` / `cmd+j ,`) and `journal.openNext` (`ctrl+j .` / `cmd+j .`) step backwards / forwards through journal entries relative to the file currently in focus. New setting `journal.navigation.mode` chooses between `existing` (default — skip gaps to the next entry on disk) and `calendar` (step exactly one day, create if missing). Navigation honors the active scope.
 

--- a/docs/plans/2026-05-14-feat-168-weekly-entry-granularity.md
+++ b/docs/plans/2026-05-14-feat-168-weekly-entry-granularity.md
@@ -1,0 +1,187 @@
+# Plan — Feature #168: Weekly Entry Granularity
+
+**Issue:** [pajoma/vscode-journal#168](https://github.com/pajoma/vscode-journal/issues/168)
+**Spec:** [docs/specs/2026-05-14-feat-168-weekly-entry-granularity.md](../specs/2026-05-14-feat-168-weekly-entry-granularity.md)
+**Branch:** `168-possible-to-use-weekly-instead-of-daily-for-memos-ect`
+**Date:** 2026-05-14
+**Status:** Draft — awaiting approval on issue.
+
+## Approach
+
+The granularity decision is **purely additive**. We introduce a single global setting (`journal.entryGranularity`) and translate "no explicit date target + granularity=weekly" into `input.week = currentISOWeek()` at the command layer, immediately before the existing `Reader.loadEntryForInput` routing kicks in. Because `Reader` already routes `input.hasWeek()` → `loadEntryForWeek`, and `Inject.injectInput` runs against whatever document the reader returned, every downstream consumer keeps its current contract — no changes in `Reader`, `Inject`, or `MatchInput`.
+
+For new notes (`journal:note`), the granularity check sits inside `LoadNotes` where path resolution already happens — that file becomes the only consumer of the new `journal.patterns.weeklyNotes` shape.
+
+**Trade-off considered:** an alternative is to push the decision down into `MatchInput.parseInput()` so the resulting `Input` already carries the right `week`. Rejected because `MatchInput` is text-grammar logic and should remain orthogonal to user preferences; configuration leaks into a parser would be a smell. The command-layer integration is one decision per command call, which is symmetric to how scope already gets resolved at that layer.
+
+**Smart-input grammar is untouched.** `w20`, `week 20`, `+0`, `2026-05-14`, weekday names all keep their current meaning. Granularity only kicks in when the parsed `Input` is "bare" (no `hasOffset()`, no `hasWeek()`).
+
+## Steps
+
+### 1. Manifest changes (`package.json`)
+
+1a. Add `journal.entryGranularity` enum setting under `contributes.configuration.properties`:
+   ```jsonc
+   "journal.entryGranularity": {
+     "type": "string",
+     "enum": ["daily", "weekly"],
+     "default": "daily",
+     "description": "%configuration.journal.entryGranularity.description%"
+   }
+   ```
+
+1b. Extend the `journal.patterns` default object with a `weeklyNotes` block, sibling to `notes` / `entries` / `weeks`:
+   ```jsonc
+   "weeklyNotes": {
+     "path": "${base}/${year}/w${week}",
+     "file": "${input}.${ext}"
+   }
+   ```
+
+1c. Replace the default `weekly` entry inside `journal.templates`:
+   ```jsonc
+   { "name": "weekly", "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n" }
+   ```
+
+1d. Add NLS key to `package.nls.json`:
+   ```jsonc
+   "configuration.journal.entryGranularity.description": "Whether memos, tasks, and new notes default to today's daily entry (`daily`) or the current week's weekly entry (`weekly`) when no explicit date target is given. Explicit input (date offset, ISO date, weekday, week number) always overrides this setting."
+   ```
+   No fan-out to locale `package.nls.<loc>.json` files needed (per CLAUDE.md: configuration descriptions are not localized today).
+
+### 2. Configuration helpers (`src/ext/conf.ts`)
+
+2a. Extend the local `PatternDefinition` type at the top of `conf.ts` to include the new `weeklyNotes` shape.
+
+2b. Add `getEntryGranularity()`:
+   ```typescript
+   public getEntryGranularity(_scopeId?: string): "daily" | "weekly" {
+     const raw = this.config.get<string>("entryGranularity");
+     return raw === "weekly" ? "weekly" : "daily";
+   }
+   ```
+   Scope is accepted but ignored for v1 (spec: scope-specific granularity is out of scope; the parameter exists so we don't have to change the signature later when we add it).
+
+2c. Add `getWeeklyNotesPathPattern(_scopeId?)`, `getResolvedWeeklyNotesPath(week, year, _scopeId?)`, `getWeeklyNotesFilePattern(week, year, input, _scopeId?)`. Mirror the existing `getNotesPathPattern` / `getResolvedNotesPath` / `getNotesFilePattern` (lines 280–370 of `conf.ts`) but resolve `${week}` and `${year}` instead of `${month}`/`${day}`. Reuse `replaceVariableValue` and `replaceDateFormats` from `src/util/strings.ts`.
+
+### 3. Granularity hook in command layer (`src/provider/commands/show-entry-for-date.ts`)
+
+3a. In `AbstractLoadEntryForDateCommand.execute(input)`, immediately after the entry guard and before `promptLocalOrRemoteInRemoteSession`, add:
+   ```typescript
+   this.applyEntryGranularity(input);
+   ```
+
+3b. Define `protected applyEntryGranularity(input: J.Model.Input): void`:
+   ```typescript
+   protected applyEntryGranularity(input: J.Model.Input): void {
+     if (input instanceof J.Model.NoteInput) { return; }      // notes handled separately
+     if (input instanceof J.Model.SelectedInput) { return; }  // explicit file path
+     if (input.hasWeek()) { return; }                          // explicit week wins
+     if (input.hasOffset()) { return; }                        // explicit offset wins (incl. "today" / "+0")
+
+     if (this.ctrl.config.getEntryGranularity() === "weekly") {
+       input.week = J.Util.getCurrentISOWeek(new Date());
+     }
+   }
+   ```
+   `getCurrentISOWeek` exists implicitly via `moment().week()` (used in `src/test/suite/week-input.test.ts`); expose it as a util in `src/util/dates.ts` for clean reuse — single line wrapper, no behavior change.
+
+3c. **Verify `hasOffset()` semantics for a bare smart input.** Empirical check: run `MatchInput.parseInput("memo: buy milk")` and assert `hasOffset()` is false. The model code (`input.ts:140`) returns `!isNaN(this.offset) && this._week === -1`. If the bare default `_offset = 0` would return `true` here, MatchInput must explicitly set `_offset = NaN` for the "no date provided" path — confirm in `match-input.ts` and fix the parser if needed (this is a parser-correctness bug regardless of #168). One short unit test pins this contract.
+
+### 4. Notes routing (`src/provider/features/load-note.ts`)
+
+4a. In `LoadNotes`, before resolving the notes path, check granularity:
+   ```typescript
+   const granularity = this.ctrl.config.getEntryGranularity(this.input.scope);
+   if (granularity === "weekly") {
+     // resolve via getResolvedWeeklyNotesPath / getWeeklyNotesFilePattern
+   } else {
+     // existing path: getResolvedNotesPath / getNotesFilePattern
+   }
+   ```
+4b. The week number / year used for resolution comes from `J.Util.getCurrentISOWeek(input.date ?? new Date())`. `LoadNotes` already has access to either the user-provided date or "now".
+
+### 5. Tests (`src/test/suite/`)
+
+5a. New file `src/test/suite/issue-168-entry-granularity.test.ts`. Test scenarios listed below. Follow the established pattern in `commands-prev-next.test.ts` and `issue-51-remote-create.test.ts`: fresh `Ctrl` per test, `TestLogger` with `errors[]` accumulator, monkey-patch `(ctrl.ui as any).openDocument`, restore in teardown.
+
+5b. Add one assertion to `phase1-regression.test.ts` (or a new test in the new file): the updated default `weekly` template still resolves with `${week}` substituted (the existing `#167` test asserts `tpl.value.includes("7")` — verify it still passes against `"# Week ${week}\n\n## Tasks\n\n## Notes\n\n"`).
+
+### 6. Docs (`docs/`)
+
+6a. `docs/settings.md` — new "Entry granularity" section under "Other options", mirroring the "Navigation Mode" entry added in #144.
+
+6b. `docs/memos.md`, `docs/tasks.md`, `docs/notes.md` — one short paragraph each explaining the granularity setting and the explicit-override rule.
+
+6c. `docs/weekly-entries.md` — new page (or extend the existing weekly entry docs if any) covering the default template, the `## Tasks` / `## Notes` anchors, and the path pattern for weekly notes.
+
+### 7. CHANGELOG (`CHANGELOG.md`)
+
+7a. New entry under `## Unreleased / ### Added`:
+   ```markdown
+   * [Issue #168](https://github.com/pajoma/vscode-journal/issues/168) New setting `journal.entryGranularity` (`daily` default, `weekly` alternative) routes memos, tasks, and new notes into the current week's entry / weekly notes folder when no explicit date target is given. Explicit date input (offset, ISO date, weekday, week number) still wins. Default `weekly` template now includes `## Tasks` and `## Notes` sections; new `journal.patterns.weeklyNotes` default controls the weekly notes path.
+   ```
+
+### 8. Open PR with `Fixes #168`
+
+Targets `develop`. Title: `feat(granularity): journal.entryGranularity routes memos/tasks/notes weekly (#168)`.
+
+## Test scenarios
+
+Each scenario maps to an acceptance criterion from the spec.
+
+| # | Scenario | Type | Asserts |
+|---|----------|------|---------|
+| T1 | `getEntryGranularity` defaults to `"daily"` when setting is unset | unit | `conf.getEntryGranularity()` returns `"daily"` |
+| T2 | `getEntryGranularity` returns `"weekly"` when setting is `"weekly"` | unit | after `config.update("entryGranularity", "weekly", Workspace)`, returns `"weekly"` |
+| T3 | Granularity hook is a no-op when `input.hasOffset()` | unit | input with `_offset=0` (today), `_week=-1`, granularity=`weekly` → `applyEntryGranularity` leaves `hasWeek()=false` |
+| T4 | Granularity hook is a no-op when `input.hasWeek()` | unit | input with `_week=20`, granularity=`weekly` → `applyEntryGranularity` leaves `_week=20` (no mutation) |
+| T5 | Granularity hook flips bare input to current week when granularity=`weekly` | unit | input with `_offset=NaN`, `_week=-1`, granularity=`weekly` → `applyEntryGranularity` sets `_week=currentISOWeek()` |
+| T6 | `MatchInput.parseInput("memo: buy milk")` leaves `hasOffset()` false | unit | empirical contract pin for the parser; required for T5 hook to fire |
+| T7 | End-to-end: smart input "memo: buy milk" with granularity=`weekly` opens the week's weekly file and injects memo under header | integration | weekly file exists at the configured weekly path; memo line is present; logger has no errors |
+| T8 | End-to-end: smart input "memo: buy milk" with granularity=`daily` opens today's daily file (regression) | integration | daily file path matches; memo line is present; logger has no errors |
+| T9 | End-to-end: smart input "+0 task fix bug" with granularity=`weekly` opens today's daily file (explicit-wins) | integration | daily file opened, NOT weekly |
+| T10 | End-to-end: smart input "w20 task plan release" with granularity=`daily` opens week 20's weekly file (explicit-wins) | integration | weekly file for week 20 opened, NOT daily |
+| T11 | `LoadNotes` with granularity=`weekly` resolves path under `weeklyNotes` pattern | integration | created note file path matches `${base}/${year}/w${week}/${input}.${ext}` |
+| T12 | `LoadNotes` with granularity=`daily` resolves path under `notes` pattern (regression) | integration | created note file path matches current default `${base}/${year}/${month}/${day}/${input}.${ext}` |
+| T13 | Default `weekly` template resolves to include `## Tasks` and `## Notes` sections | unit | `getWeeklyTemplate(7).value` contains both substrings |
+| T14 | #167 regression test still passes against new default template | regression | existing `phase1-regression.test.ts:10` continues green |
+
+Unit tests live in the new `issue-168-entry-granularity.test.ts`; integration tests share that file (the established convention for the previous bug-numbered test files).
+
+## Dependencies
+
+- **Builds on:** #167 — fix merged in PR #183 (already in `develop` per current branch base). User-customized weekly templates now resolve correctly, which #168 needs so users can edit the template to taste once granularity flips them onto the weekly file.
+- **Should not block:** #185 (weekly page auto-sync of daily entry links) — that issue is complementary but independent. #168 can ship first; #185 can come later and key off the same `weekly` template structure.
+- **No upstream PR blockers.**
+
+## Risk
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| Default `weekly` template change breaks the #167 regression test (asserts `tpl.value.includes("7")`) | low | The `${week}` substitution still runs against the new template; assertion remains true. Verified by T14. |
+| `hasOffset()` returning `true` for bare input prevents the hook from firing | medium | T6 pins the parser contract. If broken, fix `MatchInput` to set `_offset = NaN` when no date capture group matched. |
+| `journal.patterns.weeklyNotes` new shape breaks existing `PatternDefinition` type narrowing | low | Type is local to `conf.ts`. Add the field; existing users without it fall back to defaults via `defaultPatternDefinition`. |
+| Scope users surprised that scoped memos still go to daily entries under granularity=`weekly` | low | Spec called this out as out-of-scope for v1. Documented in `docs/settings.md` as a known limitation. |
+| Watcher / sync feature (#185) assumes daily-default and breaks | n/a | #185 is not yet implemented; the issue body already cross-links #168 and will be designed against the new defaults. |
+| `MatchInput` regex change required to recognize "memo" without a date prefix | medium | If `MatchInput` currently *only* sets `flags=memo` when a date capture group fires, the bare input "memo: buy milk" might not be classified as a memo. Run T6/T7 early in implementation to catch this. If broken, the parser fix is small (the existing fallback at `match-input.ts:69` already handles "text but no flags" — likely already correct). |
+
+## Rollback
+
+If the feature ships broken and we need to disable it post-release without reverting:
+
+1. The setting defaults to `"daily"`, so users who don't opt in are unaffected.
+2. Users who opted in and hit a bug can set `journal.entryGranularity = "daily"` and continue.
+3. If full revert is needed: revert the PR. The setting becomes inert (VS Code ignores unknown settings); no migration needed.
+4. The default weekly template change is a soft revert risk — users who already opened a weekly entry on the new default will have `## Tasks` / `## Notes` sections in their existing files. That is content, not config, and revert won't touch it (per spec, no file migration). Acceptable.
+
+## Reference
+
+- Spec: [docs/specs/2026-05-14-feat-168-weekly-entry-granularity.md](../specs/2026-05-14-feat-168-weekly-entry-granularity.md)
+- Related issues: #167 (just merged), #103 (original weekly feature), #185 (complementary follow-up — weekly auto-sync)
+- Reference patterns:
+  - `src/provider/features/load-note.ts` — note creation flow
+  - `src/provider/commands/show-entry-for-date.ts:37` — `AbstractLoadEntryForDateCommand.execute` integration point
+  - `src/ext/conf.ts:280-370` — notes path resolution to mirror for `weeklyNotes`
+  - `src/test/suite/phase1-regression.test.ts:10` — `#167` regression test (must remain green)
+  - `src/test/suite/commands-prev-next.test.ts` — test pattern template (fresh `Ctrl`, `TestLogger.errors[]`, monkey-patch seams)

--- a/docs/plans/2026-05-14-feat-185-weekly-daily-link-sync.md
+++ b/docs/plans/2026-05-14-feat-185-weekly-daily-link-sync.md
@@ -1,0 +1,237 @@
+# Plan — Feature #185: Weekly Page Auto-Sync of Daily Entry Links
+
+**Issue:** [pajoma/vscode-journal#185](https://github.com/pajoma/vscode-journal/issues/185)
+**Spec:** [docs/specs/2026-05-14-feat-185-weekly-daily-link-sync.md](../specs/2026-05-14-feat-185-weekly-daily-link-sync.md)
+**Branch:** `168-possible-to-use-weekly-instead-of-daily-for-memos-ect` (bundled with #168)
+**Date:** 2026-05-14
+**Status:** Draft — awaiting approval on issue.
+
+## Approach
+
+A new feature class `SyncDailyLinks` is the workhorse: given a weekly `TextDocument`, week, year, and scope, it enumerates daily files for the week from the configured `entries` path pattern (via `Reader` / `Configuration`), renders link lines from the configured template, and replaces the anchored block in the weekly doc with the rendered set. The class is pure-by-default: it takes a doc and a URI list, returns a string, and only the final `applyBlock` step performs an `applyEdit`.
+
+A separate `WeeklyEntryWatcher` owns lifecycle: it listens to `onDidChangeActiveTextEditor`, recognizes weekly files via a new `getWeekFromURIAndConfig` helper, and registers a narrow `FileSystemWatcher` over the day URIs of that ISO week. On FS events, it debounces (500 ms) and re-invokes `SyncDailyLinks.sync`. On editor change away from a weekly file, it disposes the watcher.
+
+Insertion into the existing pipeline happens in two places, mirroring how `#168` integrated:
+- `Reader.loadEntryForWeek` returns the doc as today; we wrap the call site in `AbstractLoadEntryForDateCommand.loadPageForInput` to invoke `SyncDailyLinks.sync` after the existing `Inject.injectInput` step, so opening a weekly file from any command runs the initial sync.
+- `Startup.registerCommands` instantiates and registers `WeeklyEntryWatcher` once per extension activation; its disposable is pushed onto `context.subscriptions`.
+
+**Trade-offs:**
+- *Sync on open vs. sync on watcher events only.* Synced on both — open guarantees the file is in the right state when first viewed; the watcher handles edits during the session. Skipping the open-time sync would leave stale state in the file.
+- *FS watcher vs. polling.* FS watcher only. Polling is wasteful and can miss rapid create+delete. The downside (some platforms with flaky watchers) is accepted; the issue body explicitly asks for auto-sync, which implies event-driven.
+- *Replace block vs. line-by-line diff.* Whole-block replace. Simpler, deterministic, no edge cases around partial conflicts. The user-visible cost (their cursor moves if it was inside the block while sync ran) is acceptable because the block is generated, not authored.
+- *Single watcher per active editor vs. one per scope.* One per active editor. Multi-editor splits with two weekly files would still work because each editor switch retriggers registration; the key in the map is the URI string.
+
+## Steps
+
+### 1. Manifest changes (`package.json`)
+
+1a. Add `journal.weeklySync` to `contributes.configuration.properties`:
+```jsonc
+"journal.weeklySync": {
+  "type": "object",
+  "default": {
+    "enabled": true,
+    "anchor": "## Daily Entries",
+    "template": "- [${weekday}, ${d:MMMM DD}](${link})",
+    "sortOrder": "ascending"
+  },
+  "description": "%configuration.journal.weeklySync.description%"
+}
+```
+
+1b. Add `dailyLink` to the `journal.templates` default array:
+```jsonc
+{ "name": "dailyLink", "template": "- [${weekday}, ${d:MMMM DD}](${link})", "after": "## Daily Entries" }
+```
+
+1c. Update the default `weekly` template (already updated by #168) to also include the `## Daily Entries` anchor:
+```jsonc
+{ "name": "weekly", "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n## Daily Entries\n\n" }
+```
+
+1d. Add NLS keys to `package.nls.json`:
+- `configuration.journal.weeklySync.description`
+
+### 2. Configuration helpers (`src/ext/conf.ts`)
+
+2a. Local type:
+```typescript
+type WeeklySyncConfig = {
+  enabled: boolean;
+  anchor: string;
+  template: string;
+  sortOrder: "ascending" | "descending";
+};
+```
+
+2b. `public getWeeklySyncConfig(_scopeId?: string): WeeklySyncConfig` — reads `journal.weeklySync`, falls back to defaults per field. Scope parameter accepted for forward-compat (unused in v1).
+
+2c. `public async getDailyLinkInlineTemplate(_scopeId?: string): Promise<InlineTemplate>` — mirrors `getFileLinkInlineTemplate`, looks up the `dailyLink` template id with the `${weekday}, ${d:MMMM DD}` default.
+
+### 3. Date utilities (`src/util/dates.ts`)
+
+3a. `export function getDatesOfISOWeek(week: number, year: number): Date[]` — returns 7 `Date`s from Monday → Sunday of the given ISO week / weekYear using `moment().isoWeek(week).isoWeekYear(year).startOf("isoWeek")` and 6 day increments. Used by both `SyncDailyLinks` and the watcher.
+
+### 4. URI helpers (`src/util/paths.ts`)
+
+4a. `export async function getWeekFromURIAndConfig(uri: vscode.Uri, ctrl: J.Util.Ctrl): Promise<{ week: number; year: number; scope: string } | undefined>` — mirrors the existing `getDateFromURIAndConfig`. Iterates configured scopes (longest base first), matches the URI against each scope's resolved `weeks.path` + `weeks.file` patterns, extracts week and year via regex against the resolved template. Returns `undefined` when no match.
+
+### 5. New feature `src/provider/features/sync-daily-links.ts`
+
+5a. Class skeleton (per spec interface):
+```typescript
+export class SyncDailyLinks {
+  constructor(public ctrl: J.Util.Ctrl) {}
+  public async sync(doc: TextDocument, week: number, year: number, scope?: string): Promise<void>;
+  public async findDailyEntriesForWeek(week: number, year: number, scope?: string): Promise<vscode.Uri[]>;
+  public async renderBlock(doc: TextDocument, dailies: vscode.Uri[], scope?: string): Promise<string>;
+  public async applyBlock(doc: TextDocument, anchor: string, block: string): Promise<boolean>;
+}
+```
+
+5b. `findDailyEntriesForWeek`:
+- Computes the seven `Date`s via `getDatesOfISOWeek(week, year)`.
+- For each, resolves the entry path via `Configuration.getResolvedEntryPath` + `getEntryFilePattern`, builds the absolute file path, and runs `J.Util.fileExists` (stat-first, no open antipattern).
+- Returns the URIs of existing files in date-ascending order.
+
+5c. `renderBlock`:
+- Reads `getDailyLinkInlineTemplate` and `getWeeklySyncConfig` for sort order.
+- For each URI: builds a `relativePath` from the weekly doc's dir, substitutes `${weekday}`, `${d:...}`, `${link}`, `${title}` into the template via `replaceDateFormats` + `replaceVariableValue`.
+- Joins lines with `\n`; if `sortOrder === "descending"`, reverses the list before joining.
+
+5d. `applyBlock`:
+- Locates the anchor line in the doc via `doc.getText().split("\n")` (one full read).
+- If anchor is missing, logs `debug` and returns `false` (no edit, no error toast).
+- Computes the block-end line as the next markdown heading (`/^#+\s+/`) or `doc.lineCount`.
+- Compares the existing block text with the new block text. If equal (after normalizing trailing whitespace), returns `false` (idempotent no-op).
+- Otherwise, uses `vscode.WorkspaceEdit` to replace the range `[anchorLine+1, blockEndLine)` with `\n${block}\n` (one leading blank, one trailing blank for markdown tidiness).
+
+5e. `sync` orchestrates: short-circuit if `enabled=false`; otherwise invoke `find → render → apply`. Logs `info` when the block is updated.
+
+### 6. New feature `src/provider/features/weekly-entry-watcher.ts`
+
+6a. Class:
+```typescript
+export class WeeklyEntryWatcher implements vscode.Disposable {
+  private activeWatcher: vscode.FileSystemWatcher | undefined;
+  private activeUri: string | undefined;
+  private debounceHandle: NodeJS.Timeout | undefined;
+
+  constructor(public ctrl: J.Util.Ctrl, public sync: SyncDailyLinks) {
+    this.editorListener = vscode.window.onDidChangeActiveTextEditor(e => this.handleEditorChange(e));
+    this.handleEditorChange(vscode.window.activeTextEditor);
+  }
+
+  public dispose(): void { /* dispose watcher + listener */ }
+}
+```
+
+6b. `handleEditorChange`:
+- If the editor is undefined, dispose current watcher and return.
+- Resolve `getWeekFromURIAndConfig(editor.document.uri, ctrl)`. If `undefined` (not a weekly file), dispose current watcher and return.
+- If the URI string equals `activeUri`, no-op (same weekly file regained focus).
+- Dispose the old watcher; register a new one with globs covering the seven daily paths of the resolved (week, year, scope).
+- Trigger `sync.sync(doc, week, year, scope)` once immediately.
+
+6c. Watcher's `onDidCreate / onDidChange / onDidDelete` all call a shared `scheduleSync()` that sets `debounceHandle` to fire after 500 ms; subsequent events cancel the previous timer.
+
+### 7. Wire into Startup (`src/ext/startup.ts`)
+
+7a. In `registerCommands` (or a new private `registerWeeklySync(ctrl, context)`):
+```typescript
+const syncDailyLinks = new J.Provider.SyncDailyLinks(ctrl);
+const watcher = new J.Provider.WeeklyEntryWatcher(ctrl, syncDailyLinks);
+context.subscriptions.push(watcher);
+```
+
+7b. Also invoke `syncDailyLinks.sync(doc, week, year, scope)` from `AbstractLoadEntryForDateCommand.loadPageForInput` after the `Inject.injectInput` step when `input.hasWeek()` — initial sync on weekly open from any command path. Gate on `getWeeklySyncConfig().enabled`.
+
+### 8. Tests (`src/test/suite/issue-185-weekly-sync.test.ts`)
+
+8a. Suite "URI helper" — `getWeekFromURIAndConfig` recognizes the default weekly pattern and returns `{week, year, scope}`; returns `undefined` for non-weekly URIs.
+
+8b. Suite "SyncDailyLinks rendering" — pure unit tests on `renderBlock` against seeded URIs (no I/O). Cover sort order both directions, template substitution.
+
+8c. Suite "SyncDailyLinks orchestration" — seed three daily files for week N, open the weekly file, run `sync`, assert the file content under `## Daily Entries` matches the expected three lines in ascending order.
+
+8d. Suite "Idempotency" — call `sync` twice with no FS changes between; assert the second call returns `applied=false` and the file mtime / content is unchanged.
+
+8e. Suite "Missing anchor" — open a weekly file without `## Daily Entries`; run `sync`; assert no edit and one debug message logged.
+
+8f. Suite "Watcher lifecycle" — instantiate `WeeklyEntryWatcher`, simulate editor change to a weekly file (assert watcher registered), then to a non-journal file (assert previous watcher disposed). Spy on `FileSystemWatcher.dispose`.
+
+8g. Suite "Settings" — `getWeeklySyncConfig` defaults, override individual fields, verify defaults survive when only one field is customized.
+
+8h. Regression: existing `phase1-regression.test.ts:10` weekly template test must remain green against the new default template (`## Daily Entries` heading appended).
+
+### 9. Docs
+
+9a. `docs/settings.md` — new "Weekly Sync" subsection under "Other options", documenting `journal.weeklySync` fields and explaining the daily-link auto-sync behavior. Cross-link to the new `docs/weekly-entries.md`.
+
+9b. `docs/weekly-entries.md` (new) — full feature page: how the sync works, where the anchor lives, the default template variables, how to customize for users with non-default weekly templates, the "missing anchor" graceful degradation.
+
+### 10. CHANGELOG
+
+10a. New `### Added` entry under `## Unreleased`:
+```markdown
+* [Issue #185](https://github.com/pajoma/vscode-journal/issues/185) Weekly entries now auto-sync a list of links to all daily entries in the same ISO week, kept up to date while the weekly file is the active editor. New `journal.weeklySync` setting block (`enabled`, `anchor`, `template`, `sortOrder`) controls the behavior. Default `weekly` template ships with a `## Daily Entries` heading; user-customized templates without the anchor are skipped silently. Daily files are never modified — sync is one-directional.
+```
+
+### 11. PR
+
+Will be opened as a bundled PR for #168 + #185 after this implementation lands. Body references both issues and uses `Fixes #168` + `Fixes #185` keywords.
+
+## Test scenarios
+
+| # | Scenario | Type | Asserts |
+|---|----------|------|---------|
+| W1 | `getWeekFromURIAndConfig` on a default weekly path returns `{week, year, scope}` | unit | parses the resolved pattern |
+| W2 | `getWeekFromURIAndConfig` on a non-journal URI returns `undefined` | unit | safe negative |
+| W3 | `getWeeklySyncConfig` returns the documented defaults when unset | unit | structural equality |
+| W4 | `getWeeklySyncConfig` reads individual user overrides without dropping defaults | unit | partial override merges |
+| W5 | `SyncDailyLinks.findDailyEntriesForWeek` returns existing daily URIs only, sorted ascending | integration | seed Mon/Wed/Fri, assert 3 URIs in date order |
+| W6 | `SyncDailyLinks.renderBlock` substitutes weekday + link variables | unit | rendered output matches expected lines |
+| W7 | `SyncDailyLinks.renderBlock` honors `sortOrder=descending` | unit | output reversed |
+| W8 | `SyncDailyLinks.sync` injects the block under `## Daily Entries` (golden path) | integration | file content updated, no errors logged |
+| W9 | `SyncDailyLinks.sync` is idempotent on second call with same state | integration | second call applies no edit |
+| W10 | `SyncDailyLinks.sync` skips silently when anchor is missing | integration | no edit, debug log present |
+| W11 | `SyncDailyLinks.sync` respects `enabled=false` | integration | no edit even when anchor present |
+| W12 | `WeeklyEntryWatcher` registers a watcher when active editor becomes a weekly file | integration | spy on watcher creation |
+| W13 | `WeeklyEntryWatcher` disposes the previous watcher when editor changes away from weekly | integration | spy on dispose |
+| W14 | Creating a new daily file while weekly is active triggers a sync within 500ms | integration | wait 700ms, assert file updated |
+| W15 | Deleting a daily file while weekly is active removes the line | integration | same pattern as W14 |
+| W16 | Default `weekly` template includes `## Daily Entries` heading | unit | `getWeeklyTemplate(7).value` contains the substring |
+| W17 | #167 + #168 regression assertions stay green | regression | run existing tests in suite |
+
+## Dependencies
+
+- **Builds on #168** (same branch): `getCurrentISOWeek`, `getISOWeekYear`, and the updated `weekly` template default already exist after #168's commits. #185 layers `## Daily Entries` on top.
+- **Reuse:** `fileExists` (#51), `getDateFromURIAndConfig` pattern (#144), `SyncNoteLinks` shape (#103 era).
+
+## Risk
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| FS watcher fires for unrelated file changes inside the same year directory and re-syncs needlessly | medium | Scope the watcher glob to the seven specific daily file paths of the active week, not a broad directory match. Debounce 500ms. |
+| User keeps cursor inside the `## Daily Entries` block while sync runs and edit shifts their cursor | low | Sync only on FS events, not on text changes. The user does not type inside the synced block in normal workflow. |
+| Anchor detection is fragile for users who heavily customize weekly template | medium | Anchor is the *exact configured string* matched against any line in the file. Skip silently if not found; log a debug message. Document the customization path in `docs/weekly-entries.md`. |
+| `getWeekFromURIAndConfig` mismatches paths under unusual `journal.patterns.weeks` overrides | low | Build the regex from the resolved pattern itself (replace `${year}` with `(\d{4})`, `${week}` with `(\d{1,2})`); document supported substitution variables in the helper's JSDoc. |
+| Default weekly template change tripping `phase1-regression.test.ts:10` (asserts `tpl.value.includes("7")`) | low | The `${week}` substitution still runs; W16/W17 verify. |
+| Two PRs combined (#168 + #185) increases blast radius of any rollback | medium | Keep commits granular and atomic so individual revert is easy. Final PR description lists both issues; if one needs revert, `git revert <commit>` is per-feature. |
+
+## Rollback
+
+- `journal.weeklySync.enabled = false` disables the feature without revert.
+- For a hard revert, `git revert` the implementation commits (one for the feature, one for the watcher, one for the manifest changes). The `## Daily Entries` heading remains in user files but is harmless content.
+- The default weekly template change can be soft-reverted by users editing `journal.templates` directly.
+
+## Reference
+
+- Spec: [docs/specs/2026-05-14-feat-185-weekly-daily-link-sync.md](../specs/2026-05-14-feat-185-weekly-daily-link-sync.md)
+- Sibling: [docs/plans/2026-05-14-feat-168-weekly-entry-granularity.md](2026-05-14-feat-168-weekly-entry-granularity.md)
+- Reference patterns:
+  - `src/provider/features/sync-note-links.ts` — feature shape
+  - `src/util/paths.ts` (`getDateFromURIAndConfig`) — URI → metadata helper template
+  - `src/util/fs-exists.ts` — stat-first existence check
+  - `src/util/dates.ts` (`getCurrentISOWeek`, `getISOWeekYear`) — ISO week helpers added in #168

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -229,4 +229,24 @@ Controls how the `Open Previous Journal Entry` (`ctrl+j ,`) and `Open Next Journ
 
 The anchor is the currently open journal entry. When no journal file is open, the anchor falls back to today. Navigation honors the active scope — derived from the anchor file's path or the default scope when no anchor file is open.
 
+### Entry Granularity
+* Key: `journal.entryGranularity`
+* Default value: `daily`
+* Allowed values: `daily`, `weekly`
+
+Controls where quick memos, tasks, and new notes go when you have not typed an explicit date target into the smart input.
+
+| Value | Behavior |
+|-------|----------|
+| `daily` *(default)* | Memos / tasks inject into today's daily entry; new notes land under `${base}/${year}/${month}/${day}` (the existing `journal.patterns.notes` path). |
+| `weekly` | Memos / tasks inject into the current ISO week's weekly entry; new notes land under `${base}/${year}/w${week}` (the new `journal.patterns.weeklyNotes` path). |
+
+Explicit date input always overrides this setting. `+0 task ...` still goes to today, `2026-05-13 memo: ...` still goes to that date, `w20 task ...` still goes to week 20.
+
+When you switch to `weekly`, make sure the `journal.templates` entry named `weekly` includes the `## Tasks` and `## Notes` section headings — the default template that ships with the extension already does, so this only matters if you previously customized your weekly template. The new `journal.patterns.weeklyNotes` block (defaulting to `${base}/${year}/w${week}` for the path and `${input}.${ext}` for the file) is also configurable per scope.
+
+Known limitations:
+- Granularity is a global setting in this release. Per-scope override (e.g., personal weekly + work daily) is not yet supported.
+- Switching granularity does not move files already on disk; both layouts can coexist.
+
 ![Screen Capture](./set-base-directory.gif)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -249,4 +249,19 @@ Known limitations:
 - Granularity is a global setting in this release. Per-scope override (e.g., personal weekly + work daily) is not yet supported.
 - Switching granularity does not move files already on disk; both layouts can coexist.
 
+### Weekly Sync
+* Key: `journal.weeklySync`
+* Default value: `{ "enabled": true, "anchor": "## Daily Entries", "template": "- [${weekday}, ${d:MMMM DD}](${link})", "sortOrder": "ascending" }`
+
+When a weekly entry is the active editor, the extension automatically maintains a list of links to every daily entry that exists within the same ISO week, keeping the block up to date as daily files are created or deleted.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Set to `false` to disable the feature entirely — no edits, no watcher. |
+| `anchor` | `## Daily Entries` | The exact heading line the sync searches for. Add this heading to your weekly template if you customized it. Files without the anchor are left untouched. |
+| `template` | `- [${weekday}, ${d:MMMM DD}](${link})` | Template for each link line. Supports `${weekday}`, `${d:...}`, `${link}`, `${title}`. |
+| `sortOrder` | `ascending` | `ascending` = Monday → Sunday. `descending` = Sunday → Monday. |
+
+The default `weekly` template ships with the `## Daily Entries` heading. If you have customized your weekly template and want to opt in, add `## Daily Entries` as a separate section heading in your template. Weekly files without the anchor are silently skipped.
+
 ![Screen Capture](./set-base-directory.gif)

--- a/docs/specs/2026-05-14-feat-168-weekly-entry-granularity.md
+++ b/docs/specs/2026-05-14-feat-168-weekly-entry-granularity.md
@@ -1,0 +1,154 @@
+# Spec — Feature #168: Weekly Entry Granularity
+
+**Issue:** [pajoma/vscode-journal#168](https://github.com/pajoma/vscode-journal/issues/168)
+**Branch:** `168-possible-to-use-weekly-instead-of-daily-for-memos-ect`
+**Date:** 2026-05-14
+**Status:** Draft — awaiting approval on issue.
+
+## Goal
+
+Let users default-route memos, tasks, and new notes into the current week's journal entry (and a weekly notes folder) instead of today's daily entry, while keeping explicit date input (`+0`, `2026-05-14`, weekday names) working as-is.
+
+## Why now
+
+Issue #168 (assigned to @pajoma, milestone 1.1.0) was opened by @swoopdk: their personal workflow is weekly-granular, so a daily entry per day produces too many files. They want one entry per week and need the quick-add memo / task features to land in that weekly file. The current code already supports inline injection into a weekly entry when the user explicitly types `w20 task ...`, but there is no way to make weekly the default — so every quick memo requires typing the `w` prefix. The setting should make the weekly workflow first-class.
+
+## In scope
+
+- New configuration setting `journal.entryGranularity`: enum, allowed values `"daily"` (default) and `"weekly"`.
+- When `entryGranularity = "weekly"`, smart-input commands that have **no explicit date target** (no offset, no ISO date, no weekday, no week number) route the resulting entry to the **current ISO week's** weekly entry (using the existing weekly path pattern) instead of today's daily entry.
+- Inline injection of memo / task into the weekly entry. The injection plumbing (`Inject.injectInput`) already runs against whatever document the reader returned, so this works automatically once the reader hands back a weekly doc.
+- New notes pattern `journal.patterns.weeklyNotes` (path + file) used when `entryGranularity = "weekly"`. Default:
+  ```json
+  "weeklyNotes": {
+    "path": "${base}/${year}/w${week}",
+    "file": "${input}.${ext}"
+  }
+  ```
+- Default `weekly` template in `journal.templates` gains `## Tasks` and `## Notes` sections, so the inline memo / task injection `after` anchors (`## Tasks`) match. New default:
+  ```
+  # Week ${week}\n\n## Tasks\n\n## Notes\n\n
+  ```
+
+## Out of scope
+
+- Per-type granularity (separate settings for memos vs tasks vs notes). Single global toggle for v1; we can split later if requested.
+- Scope-specific granularity (granularity is global; scopes still control path patterns and templates independently).
+- Migration / move-on-disk of files created under the old (daily) layout. Users switching mid-stream keep both layouts side by side.
+- Changing the default `entries` (daily) pattern — daily entries still exist, granularity only chooses the default *target*.
+- Per-scope override of `entryGranularity` (could be added later under `journal.scopes[].entryGranularity`).
+- Smart-input grammar changes — the existing `w`, `week`, `w20` tokens still work and still win as explicit input.
+
+## Acceptance criteria
+
+1. Setting `journal.entryGranularity` is registered in `package.json` with enum `["daily", "weekly"]`, default `"daily"`, and is documented in `docs/settings.md`.
+2. With `entryGranularity = "daily"` (default), behavior is unchanged: smart input `memo: buy milk` injects into today's entry under `## Tasks`. The existing `phase1-regression.test.ts` continues to pass without modification.
+3. With `entryGranularity = "weekly"`:
+   - `memo: buy milk` (no date prefix) injects into the current week's weekly entry (`Journal/2026/week_<week>.md` per default pattern) under `## Tasks`.
+   - `task pay rent` (no date prefix) injects into the same weekly entry.
+   - `note: Project Ideas` creates a file under the new weekly notes pattern (`Journal/2026/w<week>/Project_Ideas.md` per default).
+4. With `entryGranularity = "weekly"`, explicit date input still wins:
+   - `+0 task fix bug` injects into today's daily entry.
+   - `2026-05-13 memo: groceries` injects into the daily entry for 2026-05-13.
+   - `w20 task plan release` injects into week 20's weekly entry (already worked).
+5. Default `weekly` template in `journal.templates` renders `# Week ${week}\n\n## Tasks\n\n## Notes\n\n` so inline injection `after` anchors match.
+6. Setting label and description appear in all 11 locale `package.nls*.json` files for the manifest label; runtime user-facing strings (if any new toasts are introduced) added to `l10n/bundle.l10n.<loc>.json`.
+7. `npm run check` (lint + compile + test) passes.
+
+## Entities / contracts / interfaces
+
+### Settings (manifest)
+
+```jsonc
+// package.json
+"journal.entryGranularity": {
+  "type": "string",
+  "enum": ["daily", "weekly"],
+  "default": "daily",
+  "description": "%configuration.journal.entryGranularity.description%"
+}
+```
+
+```jsonc
+// package.json — journal.patterns default gains:
+"weeklyNotes": {
+  "path": "${base}/${year}/w${week}",
+  "file": "${input}.${ext}"
+}
+```
+
+```jsonc
+// package.json — journal.templates default for "weekly" becomes:
+{ "name": "weekly", "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n" }
+```
+
+### Configuration helper API
+
+```typescript
+// src/ext/conf.ts
+type EntryGranularity = "daily" | "weekly";
+
+class Configuration {
+  // new:
+  public getEntryGranularity(_scopeId?: string): EntryGranularity;
+  public getWeeklyNotesPathPattern(_scopeId?: string): string;
+  public async getResolvedWeeklyNotesPath(week: number, year: number, _scopeId?: string): Promise<ScopedTemplate>;
+  public async getWeeklyNotesFilePattern(week: number, year: number, input: string, _scopeId?: string): Promise<ScopedTemplate>;
+}
+```
+
+### Input-resolution hook
+
+```typescript
+// In MatchInput.parseInput (or its post-processing) — after the regex match has produced a candidate Input:
+//   if (input has no offset && no week && no iso date && !input.hasFlags()-of-notes-only) {
+//       const granularity = config.getEntryGranularity();
+//       if (granularity === "weekly") {
+//           input.week = currentISOWeek(today);  // sets hasWeek()=true
+//       }
+//   }
+// Exact integration point: TBD in plan; cleanest is probably to inject the granularity decision in the command layer (InsertMemoCommand / ShowEntryForInputCommand) before calling super.execute(input), so MatchInput stays purely text-parsing.
+```
+
+### Reader routing (unchanged contract)
+
+```typescript
+// src/actions/reader.ts — already routes:
+public async loadEntryForInput(input: Input): Promise<TextDocument> {
+  if (input.hasWeek()) { return this.loadEntryForWeek(input.week); }
+  return this.loadEntryForDay(input.generateDate());
+}
+```
+Nothing in Reader needs to change. The granularity decision is made earlier (at command layer or in `MatchInput` post-processing) and surfaces as `input.week` being set.
+
+### LoadNotes (weekly variant)
+
+```typescript
+// src/provider/features/load-note.ts — adjusts path resolution:
+//   if (granularity === "weekly") use getResolvedWeeklyNotesPath/getWeeklyNotesFilePattern
+//   else (current behavior) use getResolvedNotesPath/getNotesFilePattern
+```
+
+## Constraints
+
+- **Backwards compatibility:** default value must be `"daily"`. Existing users see no change unless they opt in.
+- **Scope isolation:** granularity is global for v1. A scoped user (`pers task buy milk`) still uses the daily entry under that scope, ignoring the global granularity setting. Documented as a known limitation.
+- **i18n:** new setting key must be added to `package.nls.json` for the English/default description. Locale files (`package.nls.<loc>.json`) only carry command titles today (per CLAUDE.md), so no fan-out needed there. If we introduce a runtime toast (e.g., "Switched to weekly granularity"), all 11 `l10n/bundle.l10n.<loc>.json` files need the new key.
+- **ISO week numbering:** must match the existing `${week}` variable used by `journal.patterns.weeks.file` and `getWeeklyTemplate`. Confirm by reusing the same week-number helper (currently provided via moment-via-`getCurrentWeek` or similar — to be located in implementation).
+- **No moment-only paths added:** PLAN.md Phase 3 is replacing moment with `Intl` / `date-fns`. New code should use the same helper the rest of the codebase uses today (consistency over premature migration), so the eventual cutover is mechanical.
+
+## Open questions
+
+None blocking. The smart-input integration point (command layer vs `MatchInput` post-processing) is a plan-stage decision, not a spec-stage one.
+
+## Related issues
+
+- **Builds on:** #167 (weekly template name fix, just merged in #183) — the `getWeeklyTemplate` lookup now correctly resolves user overrides, which #168 relies on so users can customize the weekly template if they want.
+- **Related:** #103 (original weekly entries feature) — this is a follow-up that makes weekly entries the *default* target, not just an opt-in.
+- **No blockers.**
+
+## Notes for the implementer
+
+- Keep changes additive. Do not touch the existing daily routing path.
+- Watch out for the `phase1-regression.test.ts:10` weekly template test — it asserts `tpl.value` includes `"7"` (the week number) on the bare default template. Updating the default template to include `## Tasks\n\n## Notes\n\n` keeps the assertion green (the `${week}` substitution still runs) but verify before opening the PR.
+- The current `getNotesFilePattern` signature takes `(date, input, scopeId)`. The weekly variant takes `(week, year, input, scopeId)` — there's no `Date` because the path is keyed off the week, not a calendar day. Don't try to retrofit a `Date` argument; the two pattern resolvers should be siblings, not subclasses.

--- a/docs/specs/2026-05-14-feat-185-weekly-daily-link-sync.md
+++ b/docs/specs/2026-05-14-feat-185-weekly-daily-link-sync.md
@@ -1,0 +1,162 @@
+# Spec — Feature #185: Weekly Page Auto-Sync of Daily Entry Links
+
+**Issue:** [pajoma/vscode-journal#185](https://github.com/pajoma/vscode-journal/issues/185)
+**Branch:** `168-possible-to-use-weekly-instead-of-daily-for-memos-ect` (bundled with #168 per user direction)
+**Date:** 2026-05-14
+**Status:** Draft — awaiting approval on issue.
+
+## Goal
+
+When a weekly entry is opened (or when a daily entry inside the same ISO week changes on disk while the weekly is the active editor), automatically inject and keep up to date a list of links to every daily entry that exists for the week's days. Sync is one-directional: daily files are the source of truth, the weekly page reflects them.
+
+## Why now
+
+#168 makes weekly entries the default routing target for memos / tasks / notes. A user who adopts weekly granularity still occasionally writes daily entries (explicit `+0`, `yesterday`, `2026-05-13`, etc.). Without a navigable index in the weekly page, those daily entries become hidden. This feature gives the weekly view a maintained table of contents pointing to the same week's daily files, so the weekly workflow stays cohesive without giving up daily entries entirely.
+
+The plumbing exists by analogy: `SyncNoteLinks` (`src/provider/features/sync-note-links.ts`) already maintains a list of links from a daily entry to its notes folder. We mirror that pattern into a new `SyncDailyLinks` feature that maintains links from a weekly entry to its daily files.
+
+## In scope
+
+- New feature `src/provider/features/sync-daily-links.ts` that, given a `TextDocument` whose path matches a configured weekly entry pattern, scans the journal base for daily files within the same ISO week, builds a deduplicated list of link lines from a configurable template, and injects / replaces them under a configured anchor section in the weekly file.
+- New configuration block `journal.weeklySync` controlling the feature:
+  - `enabled`: boolean, default `true`.
+  - `anchor`: string, default `"## Daily Entries"`.
+  - `template`: inline template string; default `"- [${weekday}, ${d:MMMM DD}](${link})"`.
+  - `sortOrder`: `"ascending"` (Mon → Sun, default) or `"descending"` (Sun → Mon).
+- New default template entry `dailyLink` inside `journal.templates`, mirroring how `files` works for notes (template + `after` anchor). The `after` anchor for `dailyLink` defaults to the value of `journal.weeklySync.anchor`.
+- Update default `weekly` template in `journal.templates` to ship with the `## Daily Entries` heading appended after `## Notes`, so the anchor is present in newly-created weekly files. The template becomes `"# Week ${week}\n\n## Tasks\n\n## Notes\n\n## Daily Entries\n\n"`.
+- Hook the sync into the weekly entry open flow: after `Reader.loadEntryForWeek` returns a document and the existing #168 injection has run, call `SyncDailyLinks.sync(doc, week, year)` to populate the section.
+- File-system watcher with a narrow scope: register a `FileSystemWatcher` over the configured daily entry path for the current week while a weekly entry is the active editor. On create / change / delete events inside that range, re-run the sync (debounced). When the active editor changes to a non-weekly file, dispose the watcher.
+- Idempotent rendering: when the anchor section already contains link lines, the sync should compute the exact target block (sorted, deduplicated) and replace the entire block under the anchor (up to the next markdown heading or end of file). It should not append duplicates or scramble user-typed content outside the block.
+- Tests covering golden path, idempotency, missing-anchor warning, create + delete during session, sort order both directions, and `enabled=false` disabling the feature.
+- Docs: short paragraph in `docs/settings.md` (under "Other options") explaining `journal.weeklySync`; new section in `docs/notes.md` or a new file under `docs/` describing the auto-sync behavior.
+
+## Out of scope
+
+- Two-way sync. Daily files are never modified by this feature; only the weekly file is touched.
+- Cross-week aggregation. A weekly file only ever lists its own ISO week's days.
+- Cross-scope aggregation. The sync uses the **anchoring weekly file's scope** (derived from its path; falls back to the default scope) and lists daily entries from that same scope only.
+- Sorting by anything other than weekday. (No custom sort key per v1.)
+- Custom template variables beyond `${weekday}`, `${d:...}`, `${link}`, `${title}`. The existing template substitution helpers already cover these.
+- Migration: weekly files that already exist on disk without the `## Daily Entries` anchor are left alone. The sync logs a warning the first time it encounters such a file and skips the inject. Users can add the anchor manually to opt in.
+- Real-time editor-side observation of unsaved changes in daily files. The watcher fires on FS events, which are good enough for create / rename / delete (the modal user behavior the issue calls out).
+
+## Acceptance criteria
+
+1. Opening a weekly entry with three existing daily files (Mon, Wed, Fri of that ISO week) results in three link lines under the `## Daily Entries` section in the weekly file, in ascending weekday order, using the configured template.
+2. Re-opening the same weekly entry without any disk changes produces no edits — the existing block is detected as already-correct and the file is left untouched (idempotent).
+3. Creating a new daily file (e.g., for Thursday of the same week) while the weekly entry is the active editor adds a fourth line to the block within the debounce window (≤ 500ms after the FS event).
+4. Deleting an existing daily file while the weekly is active removes the corresponding line from the block.
+5. With `journal.weeklySync.enabled = false`, opening a weekly entry leaves the file untouched even if the anchor is present. No watcher is registered.
+6. If the weekly file does not contain the configured anchor heading, the sync skips silently (logs a debug-level message) — no inject, no error toast.
+7. With `journal.weeklySync.sortOrder = "descending"`, the order is Sun → Mon.
+8. Changing the active editor away from a weekly entry disposes any registered file-system watcher (verified by `Disposable` count in tests, or by an explicit teardown assertion).
+9. The default `weekly` template in `package.json` ships with the `## Daily Entries` heading present.
+10. `npm run check` (lint + compile + test) passes; all existing tests stay green.
+
+## Entities / contracts / interfaces
+
+### Settings (manifest)
+
+```jsonc
+"journal.weeklySync": {
+  "type": "object",
+  "default": {
+    "enabled": true,
+    "anchor": "## Daily Entries",
+    "template": "- [${weekday}, ${d:MMMM DD}](${link})",
+    "sortOrder": "ascending"
+  },
+  "description": "%configuration.journal.weeklySync.description%"
+}
+```
+
+```jsonc
+// journal.templates additions:
+{ "name": "dailyLink", "template": "- [${weekday}, ${d:MMMM DD}](${link})", "after": "## Daily Entries" }
+```
+
+```jsonc
+// updated default weekly template (additive to #168):
+{ "name": "weekly", "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n## Daily Entries\n\n" }
+```
+
+### Configuration helpers
+
+```typescript
+type WeeklySyncConfig = {
+  enabled: boolean;
+  anchor: string;
+  template: string;
+  sortOrder: "ascending" | "descending";
+};
+
+class Configuration {
+  public getWeeklySyncConfig(_scopeId?: string): WeeklySyncConfig;
+  public async getDailyLinkInlineTemplate(_scopeId?: string): Promise<InlineTemplate>;
+}
+```
+
+### Sync feature
+
+```typescript
+// src/provider/features/sync-daily-links.ts
+export class SyncDailyLinks {
+  constructor(public ctrl: J.Util.Ctrl) {}
+
+  public async sync(weeklyDoc: vscode.TextDocument, week: number, year: number, scope?: string): Promise<void>;
+
+  // Returns the absolute file URIs of existing daily entries for the week,
+  // sorted by date ascending. Caller may reverse for descending sort.
+  public async findDailyEntriesForWeek(week: number, year: number, scope?: string): Promise<vscode.Uri[]>;
+
+  // Renders the template-driven block (no I/O); pure given the URIs.
+  public async renderBlock(weeklyDoc: vscode.TextDocument, dailies: vscode.Uri[], scope?: string): Promise<string>;
+
+  // Replaces (or inserts) the anchored block in the doc. Returns true if the file changed.
+  public async applyBlock(weeklyDoc: vscode.TextDocument, anchor: string, block: string): Promise<boolean>;
+}
+```
+
+### Watcher lifecycle
+
+```typescript
+// src/provider/features/weekly-entry-watcher.ts
+export class WeeklyEntryWatcher implements vscode.Disposable {
+  // Registered once in Startup.registerCommands (or a dedicated step).
+  // Listens to vscode.window.onDidChangeActiveTextEditor.
+  // When the active editor's URI matches the weekly file pattern for any
+  // scope, derives (week, year, scope), runs SyncDailyLinks.sync, and
+  // registers a narrow FileSystemWatcher over the week's days. Disposes
+  // the previous watcher (if any) on every transition.
+}
+```
+
+### URI → week resolution
+
+The watcher needs to recognize a weekly file from its path. Reuse `getDateFromURIAndConfig` (already used by #144 navigation) for daily entries, plus a new sibling `getWeekFromURIAndConfig` that matches the weekly path pattern (`${base}/${year}/week_${week}.${ext}` per default) and extracts `{week, year, scope}`. Both functions live in `src/util/paths.ts`.
+
+## Constraints
+
+- **Backwards compatibility:** existing users who have customized their weekly template without the `## Daily Entries` heading keep their template untouched. The sync logs a single debug message and skips. The default weekly template change only affects new installations / users who reset to default.
+- **Performance:** the FS watcher must be scoped to the current week's day paths only. A watcher over the entire base directory would re-trigger on every unrelated edit (notes, other weeks). Use a glob like `${base}/${year}/${month}/0[1-7].md` plus targeted globs for the specific dates of the active week.
+- **Idempotency:** the rendered block uses deterministic ordering (sort by date ascending or descending per setting) so repeated invocations produce identical text. The anchor + next-heading boundary determines the replace range.
+- **No moment dependency added:** reuse the existing `moment` ISO week helpers already wrapped in `src/util/dates.ts` (`getCurrentISOWeek`, `getISOWeekYear` from #168) plus a new `getDatesOfISOWeek(week, year)` returning `Date[7]` for the Mon → Sun range.
+- **Save bursts:** debounce FS events with a 500ms tail-window so a rapid create + rename produces a single sync call.
+
+## Open questions
+
+None blocking. The exact wording of the warning log when anchor is missing, and whether to expose `journal.weeklySync.warnOnMissingAnchor` as a separate toggle, can be deferred until first user feedback.
+
+## Related issues
+
+- **Builds on:** #168 (entry granularity) — the default weekly template change is layered on top of #168's `## Tasks` / `## Notes` additions, producing the final shape `"# Week ${week}\n\n## Tasks\n\n## Notes\n\n## Daily Entries\n\n"`.
+- **Related:** #103 (original weekly entry feature), `SyncNoteLinks` (the reference implementation pattern).
+- **Bundled:** ships in the same branch and PR as #168.
+
+## Notes for the implementer
+
+- The watcher should NOT inject on `onDidChangeTextDocument`. The user typing inside the weekly file must not retrigger sync (would race with their cursor). FS events only.
+- When parsing the existing block under the anchor, treat the anchor as `^${anchor}\s*$` and the end as the next markdown heading at the same or higher level (`/^#+\s/`). Do not rely on a known fixed number of lines.
+- When replacing the block, preserve a single blank line after the anchor and a single blank line before the next heading, so the file remains markdown-tidy.
+- The watcher's lifecycle is per-editor, not per-document. Two editors on the same weekly file should NOT register duplicate watchers (key the registration map by `doc.uri.toString()`).

--- a/package.json
+++ b/package.json
@@ -202,9 +202,22 @@
             "weeks": {
               "path": "${base}/${year}",
               "file": "week_${week}.${ext}"
+            },
+            "weeklyNotes": {
+              "path": "${base}/${year}/w${week}",
+              "file": "${input}.${ext}"
             }
           },
           "description": "%configuration.journal.patterns.description%"
+        },
+        "journal.entryGranularity": {
+          "type": "string",
+          "enum": [
+            "daily",
+            "weekly"
+          ],
+          "default": "daily",
+          "description": "%configuration.journal.entryGranularity.description%"
         },
         "journal.tpl-entry": {
           "type": "string",
@@ -337,7 +350,7 @@
             },
             {
               "name": "weekly",
-              "template": "# Week ${week}\n\n"
+              "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n"
             }
           ],
           "markdownDescription": "%configuration.journal.templates.description%"

--- a/package.json
+++ b/package.json
@@ -350,10 +350,25 @@
             },
             {
               "name": "weekly",
-              "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n"
+              "template": "# Week ${week}\n\n## Tasks\n\n## Notes\n\n## Daily Entries\n\n"
+            },
+            {
+              "name": "dailyLink",
+              "template": "- [${weekday}, ${d:MMMM DD}](${link})",
+              "after": "## Daily Entries"
             }
           ],
           "markdownDescription": "%configuration.journal.templates.description%"
+        },
+        "journal.weeklySync": {
+          "type": "object",
+          "default": {
+            "enabled": true,
+            "anchor": "## Daily Entries",
+            "template": "- [${weekday}, ${d:MMMM DD}](${link})",
+            "sortOrder": "ascending"
+          },
+          "description": "%configuration.journal.weeklySync.description%"
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,5 +25,6 @@
     "configuration.journal.navigation.mode.description": "How `Open Previous` and `Open Next` step through journal entries. `existing` skips gaps and only opens entries that already exist on disk. `calendar` steps exactly one day at a time and creates the entry if missing. Default: `existing`.",
     "configuration.journal.openInNewEditorGroup.description": "If true, the journal pages and new notes will split the editor view.",
     "configuration.journal.scopes.description": "Define your own scopes here, see Guide for more details.",
-    "configuration.journal.templates.description": "Definition of templates used when generate content for the journal. See Guide for more details."
+    "configuration.journal.templates.description": "Definition of templates used when generate content for the journal. See Guide for more details.",
+    "configuration.journal.weeklySync.description": "Controls the automatic sync of daily-entry links into the weekly file. When enabled, opening a weekly entry (or creating/deleting a daily entry while a weekly file is active) updates the list of links under the configured anchor heading. Set `enabled` to false to disable the feature entirely."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,6 +20,7 @@
     "configuration.journal.locale.description": "The locale to use (required for the date format). Defaults to the language setting from Visual Studio Code.",
     "configuration.journal.syntax-highlighting.description": "Enable extension specific syntax highlighting (default is false).",
     "configuration.journal.patterns.description": "Individual patterns which define where and how notes and entries are stored. Check the wiki for defaults and options.",
+    "configuration.journal.entryGranularity.description": "Whether memos, tasks, and new notes default to today's daily entry (`daily`) or the current week's weekly entry (`weekly`) when no explicit date target is given. Explicit input (date offset, ISO date, weekday, week number) always overrides this setting. Default: `daily`.",
     "configuration.journal.dev.description": "If enabled, the features in development will be activated (other features might be broken).",
     "configuration.journal.navigation.mode.description": "How `Open Previous` and `Open Next` step through journal entries. `existing` skips gaps and only opens entries that already exist on disk. `calendar` steps exactly one day at a time and creates the entry if missing. Default: `existing`.",
     "configuration.journal.openInNewEditorGroup.description": "If true, the journal pages and new notes will split the editor view.",

--- a/src/actions/parser.ts
+++ b/src/actions/parser.ts
@@ -79,10 +79,24 @@ export class Parser {
 
             let inputForFileName: string = J.Util.normalizeFilename(input.text);
 
-            Promise.all([
-                this.ctrl.config.getNotesFilePattern(date, inputForFileName, input.scope),
-                this.ctrl.config.getResolvedNotesPath(date, input.scope),
-            ])
+            const granularity = this.ctrl.config.getEntryGranularity(input.scope);
+            const filePromise = granularity === "weekly"
+                ? this.ctrl.config.getWeeklyNotesFilePattern(
+                    J.Util.getCurrentISOWeek(date),
+                    J.Util.getISOWeekYear(date),
+                    inputForFileName,
+                    input.scope,
+                )
+                : this.ctrl.config.getNotesFilePattern(date, inputForFileName, input.scope);
+            const pathPromise = granularity === "weekly"
+                ? this.ctrl.config.getResolvedWeeklyNotesPath(
+                    J.Util.getCurrentISOWeek(date),
+                    J.Util.getISOWeekYear(date),
+                    input.scope,
+                )
+                : this.ctrl.config.getResolvedNotesPath(date, input.scope);
+
+            Promise.all([filePromise, pathPromise])
 
                 .then(([fileTemplate, pathTemplate]) => {
                     path = Path.join(pathTemplate.value!, fileTemplate.value!.trim());
@@ -109,7 +123,11 @@ export class Parser {
      * @memberof Parser
      */
     public async parseInput(inputString: string): Promise<J.Model.Input> {
-        let inputMatcher = new J.Provider.MatchInput(this.ctrl.logger, this.ctrl.config.getLocale());
+        let inputMatcher = new J.Provider.MatchInput(
+            this.ctrl.logger,
+            this.ctrl.config.getLocale(),
+            this.ctrl.config.getEntryGranularity(),
+        );
         return inputMatcher.parseInput(inputString);
 
     }

--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -36,7 +36,10 @@ type PatternDefinition = {
     notes: { path: string; file: string };
     entries: { path: string; file: string };
     weeks: { path: string; file: string };
+    weeklyNotes?: { path: string; file: string };
 };
+
+export type EntryGranularity = "daily" | "weekly";
 
 var defaultPatternDefinition: PatternDefinition =
 {
@@ -51,6 +54,10 @@ var defaultPatternDefinition: PatternDefinition =
     weeks: {
         path: "${base}/${year}",
         file: "w${week}.${ext}"
+    },
+    weeklyNotes: {
+        path: "${base}/${year}/w${week}",
+        file: "${input}.${ext}"
     }
 };
 
@@ -366,6 +373,72 @@ export class Configuration {
                 reject(error);
             }
 
+        });
+    }
+
+    public getEntryGranularity(_scopeId?: string): EntryGranularity {
+        const raw = this.config.get<string>("entryGranularity");
+        return raw === "weekly" ? "weekly" : "daily";
+    }
+
+    public getWeeklyNotesPathPattern(_scopeId?: string): string {
+        let result: string | undefined;
+        if (this.resolveScope(_scopeId) === SCOPE_DEFAULT) {
+            result = this.config.get<PatternDefinition>("patterns")?.weeklyNotes?.path;
+        } else {
+            result = this.config.get<ScopeDefinition[]>("scopes")?.find(sd => sd.name === _scopeId)?.patterns?.weeklyNotes?.path;
+        }
+        if (isNullOrUndefined(result) || result!.length === 0) {
+            result = defaultPatternDefinition.weeklyNotes!.path;
+        }
+        return result!;
+    }
+
+    public async getResolvedWeeklyNotesPath(week: number, year: number, _scopeId?: string): Promise<ScopedTemplate> {
+        return new Promise((resolve, reject) => {
+            try {
+                const scopedTemplate: ScopedTemplate = {
+                    scope: (this.resolveScope(_scopeId) === SCOPE_DEFAULT) ? SCOPE_DEFAULT : _scopeId!,
+                    template: this.getWeeklyNotesPathPattern(_scopeId)
+                };
+                scopedTemplate.value = scopedTemplate.template;
+                scopedTemplate.value = replaceVariableValue("homeDir", os.homedir(), scopedTemplate.value);
+                scopedTemplate.value = replaceVariableValue("base", this.getBasePath(_scopeId), scopedTemplate.value);
+                scopedTemplate.value = replaceVariableValue("year", String(year), scopedTemplate.value);
+                scopedTemplate.value = replaceVariableValue("week", String(week), scopedTemplate.value);
+                resolve(scopedTemplate);
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    public async getWeeklyNotesFilePattern(week: number, year: number, input: string, _scopeId?: string): Promise<ScopedTemplate> {
+        return new Promise((resolve, reject) => {
+            try {
+                let definition: string | undefined;
+                const scopedTemplate: ScopedTemplate = {
+                    scope: SCOPE_DEFAULT,
+                    template: ""
+                };
+                if (this.resolveScope(_scopeId) === SCOPE_DEFAULT) {
+                    definition = this.config.get<PatternDefinition>("patterns")?.weeklyNotes?.file;
+                } else {
+                    definition = this.config.get<ScopeDefinition[]>("scopes")?.filter(sd => sd.name === _scopeId).pop()?.patterns?.weeklyNotes?.file;
+                    scopedTemplate.scope = _scopeId!;
+                }
+                if (isNullOrUndefined(definition) || definition!.length === 0) {
+                    definition = defaultPatternDefinition.weeklyNotes!.file;
+                }
+                scopedTemplate.template = definition!;
+                scopedTemplate.value = replaceVariableValue("ext", this.getFileExtension(), scopedTemplate.template);
+                scopedTemplate.value = replaceVariableValue("input", input, scopedTemplate.value);
+                scopedTemplate.value = replaceVariableValue("year", String(year), scopedTemplate.value);
+                scopedTemplate.value = replaceVariableValue("week", String(week), scopedTemplate.value);
+                resolve(scopedTemplate);
+            } catch (error) {
+                reject(error);
+            }
         });
     }
 

--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -27,6 +27,13 @@ import { replaceDateFormats, replaceVariableValue } from '../util';
 
 export const SCOPE_DEFAULT: string = "default";
 
+export type WeeklySyncConfig = {
+    enabled: boolean;
+    anchor: string;
+    template: string;
+    sortOrder: "ascending" | "descending";
+};
+
 
 
 
@@ -440,6 +447,34 @@ export class Configuration {
                 reject(error);
             }
         });
+    }
+
+    /** Returns the raw weeks path template (e.g. "${base}/${year}"), without variable substitution. */
+    public getWeeksPathPatternRaw(_scopeId?: string): string {
+        let result: string | undefined;
+        if (this.resolveScope(_scopeId) === SCOPE_DEFAULT) {
+            result = this.config.get<PatternDefinition>("patterns")?.weeks?.path;
+        } else {
+            result = this.config.get<ScopeDefinition[]>("scopes")?.find(sd => sd.name === _scopeId)?.patterns?.weeks?.path;
+        }
+        if (isNullOrUndefined(result) || result!.length === 0) {
+            result = defaultPatternDefinition.weeks.path;
+        }
+        return result!;
+    }
+
+    /** Returns the raw weeks file template (e.g. "week_${week}.${ext}"), without variable substitution. */
+    public getWeeksFilePatternRaw(_scopeId?: string): string {
+        let result: string | undefined;
+        if (this.resolveScope(_scopeId) === SCOPE_DEFAULT) {
+            result = this.config.get<PatternDefinition>("patterns")?.weeks?.file;
+        } else {
+            result = this.config.get<ScopeDefinition[]>("scopes")?.find(sd => sd.name === _scopeId)?.patterns?.weeks?.file;
+        }
+        if (isNullOrUndefined(result) || result!.length === 0) {
+            result = defaultPatternDefinition.weeks.file;
+        }
+        return result!;
     }
 
     getWeekFilePattern(week: Number, _scopeId?: string): any {
@@ -929,6 +964,24 @@ export class Configuration {
         return (!isNullOrUndefined(res)) ? res! : false;
     }
 
+
+    public getWeeklySyncConfig(_scopeId?: string): WeeklySyncConfig {
+        const raw = this.config.get<Partial<WeeklySyncConfig>>("weeklySync") ?? {};
+        return {
+            enabled:   raw.enabled   !== undefined ? raw.enabled   : true,
+            anchor:    raw.anchor    !== undefined ? raw.anchor    : "## Daily Entries",
+            template:  raw.template  !== undefined ? raw.template  : "- [${weekday}, ${d:MMMM DD}](${link})",
+            sortOrder: raw.sortOrder === "descending" ? "descending" : "ascending",
+        };
+    }
+
+    public async getDailyLinkInlineTemplate(_scopeId?: string): Promise<InlineTemplate> {
+        return this.getInlineTemplate("dailyLink", "- [${weekday}, ${d:MMMM DD}](${link})", this.resolveScope(_scopeId))
+            .then((result: InlineTemplate) => {
+                result.value = result.template;
+                return result;
+            });
+    }
 
     /***** PRIVATES *******/
 

--- a/src/ext/startup.ts
+++ b/src/ext/startup.ts
@@ -114,6 +114,10 @@ export class Startup {
 
 
         try {
+            const syncDailyLinks = new J.Provider.SyncDailyLinks(ctrl);
+            const weeklyEntryWatcher = new J.Provider.WeeklyEntryWatcher(ctrl, syncDailyLinks);
+            context.subscriptions.push(weeklyEntryWatcher);
+
             context.subscriptions.push(
                 J.Provider.Commands.OpenJournalWorkspaceCommand.create(ctrl),
                 J.Provider.Commands.PrintTimeCommand.create(ctrl),

--- a/src/provider/commands/show-entry-for-date.ts
+++ b/src/provider/commands/show-entry-for-date.ts
@@ -20,6 +20,8 @@
 import * as vscode from 'vscode';
 import * as J from '../..';
 import { NoteInput, SelectedInput, ScopedTemplate } from '../../model';
+import { getWeekFromURIAndConfig } from '../../util/paths';
+import { SyncDailyLinks } from '../features/sync-daily-links';
 
 
 export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
@@ -152,7 +154,21 @@ export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
 
         } else {
             return this.ctrl.reader.loadEntryForInput(input)
-                .then((doc: vscode.TextDocument) => this.ctrl.inject.injectInput(doc, input));
+                .then((doc: vscode.TextDocument) => this.ctrl.inject.injectInput(doc, input))
+                .then((doc: vscode.TextDocument) => {
+                    // Fire-and-forget weekly sync — must never reject loadPageForInput.
+                    getWeekFromURIAndConfig(doc.uri, this.ctrl.config)
+                        .then(weekInfo => {
+                            if (weekInfo && this.ctrl.config.getWeeklySyncConfig().enabled) {
+                                const scopeId = weekInfo.scope === 'default' ? undefined : weekInfo.scope;
+                                new SyncDailyLinks(this.ctrl)
+                                    .sync(doc, weekInfo.week, weekInfo.year, scopeId)
+                                    .catch(err => this.ctrl.logger.error("loadPageForInput: weekly sync failed:", err));
+                            }
+                        })
+                        .catch(err => this.ctrl.logger.error("loadPageForInput: getWeekFromURIAndConfig failed:", err));
+                    return doc;
+                });
         }
     }
 }

--- a/src/provider/features/match-input.ts
+++ b/src/provider/features/match-input.ts
@@ -4,8 +4,10 @@ import { Input } from "../../model/input";
 import moment = require("moment");
 import { getMonthForString } from "../../util/dates";
 
+export type EntryGranularity = "daily" | "weekly";
+
 /**
- * Feature responsible for parsing the user input and and extracting offset, flags and text. 
+ * Feature responsible for parsing the user input and and extracting offset, flags and text.
  */
 export class MatchInput {
     public today: Date;
@@ -13,7 +15,7 @@ export class MatchInput {
     private expr: RegExp | undefined;
 
 
-    constructor(public logger: Logger, public locale: string) {
+    constructor(public logger: Logger, public locale: string, public granularity: EntryGranularity = "daily") {
         this.today = new Date();
     }
 
@@ -59,6 +61,8 @@ export class MatchInput {
                 parsedInput.text = this.extractText(res!);
                 parsedInput.tags = this.extractTags(inputString);
 
+                const userProvidedTemporalToken = this.hasTemporalToken(res!);
+
 
                 // flags but no text, show error
                 if (parsedInput.hasFlags() && !parsedInput.hasMemo()) {
@@ -73,9 +77,18 @@ export class MatchInput {
                     // }
                 }
 
-                // if not temporal modifier in input, but flag and text, we default to today
-                if (!parsedInput.hasOffset() && parsedInput.hasFlags() && parsedInput.hasMemo()) {
-                    parsedInput.offset = 0;
+                // No temporal modifier in input and no explicit week: honor the configured
+                // entryGranularity. Daily (default) keeps offset=0 (today); weekly redirects
+                // the input to the current ISO week so downstream routing opens the weekly
+                // entry. Explicit user input always wins because the temporal-token check
+                // above short-circuits this block.
+                if (!userProvidedTemporalToken && !parsedInput.hasWeek()) {
+                    if (this.granularity === "weekly") {
+                        parsedInput.week = moment().week();
+                        parsedInput.offset = NaN;
+                    } else {
+                        parsedInput.offset = 0;
+                    }
                 }
 
                 resolve(parsedInput);
@@ -119,6 +132,23 @@ export class MatchInput {
         return isNotNullOrUndefined(text) ? text : "";
     }
 
+
+    /**
+     * Returns true when the user explicitly typed a temporal token
+     * (shortcut, offset, ISO date, weekday, week reference, or month + day).
+     * Distinguishes "the user said today" from "the user said nothing and we
+     * picked a default."
+     */
+    private hasTemporalToken(inputGroups: RegExpMatchArray): boolean {
+        const g = inputGroups.groups!;
+        return isNotNullOrUndefined(g["shortcut"])
+            || isNotNullOrUndefined(g["offset"])
+            || isNotNullOrUndefined(g["iso"])
+            || isNotNullOrUndefined(g["weekday"])
+            || isNotNullOrUndefined(g["week"])
+            || isNotNullOrUndefined(g["weekNum"])
+            || (isNotNullOrUndefined(g["month"]) && isNotNullOrUndefined(g["dayOfMonth"]));
+    }
 
     private extractFlags(inputGroups: RegExpMatchArray): string {
         const flagPre = inputGroups.groups!["flag"];

--- a/src/provider/features/sync-daily-links.ts
+++ b/src/provider/features/sync-daily-links.ts
@@ -1,0 +1,157 @@
+import * as vscode from 'vscode';
+import * as Path from 'path';
+import * as J from '../..';
+import { getDatesOfISOWeek, replaceDateFormats, replaceVariableValue } from '../../util';
+import { fileExists } from '../../util/fs-exists';
+
+export class SyncDailyLinks {
+
+    constructor(public ctrl: J.Util.Ctrl) { }
+
+    /**
+     * Orchestrates the full sync cycle for a weekly document: find existing
+     * daily entries → render the link block → apply the block into the doc.
+     * Short-circuits silently when weeklySync.enabled is false.
+     */
+    public async sync(
+        weeklyDoc: vscode.TextDocument,
+        week: number,
+        year: number,
+        scope?: string
+    ): Promise<void> {
+        const syncConfig = this.ctrl.config.getWeeklySyncConfig(scope);
+        if (!syncConfig.enabled) { return; }
+
+        const dailies = await this.findDailyEntriesForWeek(week, year, scope);
+        const block = await this.renderBlock(weeklyDoc, dailies, scope);
+        const applied = await this.applyBlock(weeklyDoc, syncConfig.anchor, block);
+        if (applied) {
+            this.ctrl.logger.debug("SyncDailyLinks: updated daily-entry links in", weeklyDoc.fileName);
+        }
+    }
+
+    /**
+     * Returns the URIs of existing daily entry files for the given week/year,
+     * sorted by date ascending. Uses stat-first fileExists — no speculative opens.
+     */
+    public async findDailyEntriesForWeek(
+        week: number,
+        year: number,
+        scope?: string
+    ): Promise<vscode.Uri[]> {
+        const dates = getDatesOfISOWeek(week, year);
+        const result: vscode.Uri[] = [];
+
+        for (const date of dates) {
+            const pathTpl = await this.ctrl.config.getResolvedEntryPath(date, scope);
+            const fileTpl = await this.ctrl.config.getEntryFilePattern(date, scope);
+            if (!pathTpl.value || !fileTpl.value) { continue; }
+
+            const fullPath = Path.normalize(Path.join(pathTpl.value, fileTpl.value));
+            const uri = vscode.Uri.file(fullPath);
+            if (await fileExists(uri)) {
+                result.push(uri);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Renders the link block (no I/O). Returns a string with one link line per
+     * existing daily entry, ordered per the configured sortOrder.
+     */
+    public async renderBlock(
+        weeklyDoc: vscode.TextDocument,
+        dailies: vscode.Uri[],
+        scope?: string
+    ): Promise<string> {
+        const syncConfig = this.ctrl.config.getWeeklySyncConfig(scope);
+        const tpl = await this.ctrl.config.getDailyLinkInlineTemplate(scope);
+        const weeklyDir = Path.parse(weeklyDoc.uri.fsPath).dir;
+        const locale = this.ctrl.config.getLocale();
+
+        const lines: string[] = [];
+        for (const uri of dailies) {
+            const date = await J.Util.getDateFromURIAndConfig(uri.fsPath, this.ctrl.config);
+            const relativePath = Path.relative(weeklyDir, uri.fsPath).replace(/\\/g, '/');
+
+            let line = tpl.template;
+            line = replaceDateFormats(line, date, locale);
+            line = replaceVariableValue("link", relativePath, line);
+            // ${title} substitution: filename without extension
+            const title = Path.parse(uri.fsPath).name.replace(/_/g, ' ');
+            line = replaceVariableValue("title", title, line);
+            lines.push(line);
+        }
+
+        if (syncConfig.sortOrder === "descending") {
+            lines.reverse();
+        }
+
+        return lines.join('\n');
+    }
+
+    /**
+     * Replaces (or inserts) the content under the anchor heading in weeklyDoc.
+     * The replaced range is from the line after the anchor up to (not including)
+     * the next markdown heading at any level, or end of document.
+     * Returns true if the document was modified, false if it was already correct.
+     */
+    public async applyBlock(
+        weeklyDoc: vscode.TextDocument,
+        anchor: string,
+        block: string
+    ): Promise<boolean> {
+        const text = weeklyDoc.getText();
+        const lines = text.split('\n');
+
+        // Find anchor line (exact match after trimming trailing whitespace).
+        const anchorLineIdx = lines.findIndex(l => l.trimEnd() === anchor);
+        if (anchorLineIdx === -1) {
+            this.ctrl.logger.debug(
+                "SyncDailyLinks: anchor not found in", weeklyDoc.fileName,
+                "— configure '## Daily Entries' or set journal.weeklySync.anchor"
+            );
+            return false;
+        }
+
+        // Find end of block: next markdown heading or end of doc.
+        let blockEndLineIdx = lines.length;
+        for (let i = anchorLineIdx + 1; i < lines.length; i++) {
+            if (/^#+\s/.test(lines[i])) {
+                blockEndLineIdx = i;
+                break;
+            }
+        }
+
+        // Existing block content between anchor+1 and blockEnd (exclusive).
+        const existingLines = lines.slice(anchorLineIdx + 1, blockEndLineIdx);
+        const existingBlock = existingLines
+            .map(l => l.trimEnd())
+            .join('\n')
+            .trim();
+        const newBlock = block.trim();
+
+        if (existingBlock === newBlock) {
+            return false; // idempotent — nothing to do
+        }
+
+        // Replacement: blank line, content, blank line (for markdown tidiness).
+        const replacement = '\n' + (newBlock.length > 0 ? newBlock + '\n' : '') + '\n';
+
+        const startPos = weeklyDoc.lineAt(anchorLineIdx + 1).range.start;
+        const endLine = blockEndLineIdx < weeklyDoc.lineCount
+            ? blockEndLineIdx
+            : weeklyDoc.lineCount - 1;
+        const endPos = blockEndLineIdx < weeklyDoc.lineCount
+            ? weeklyDoc.lineAt(blockEndLineIdx).range.start
+            : weeklyDoc.lineAt(endLine).range.end;
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(weeklyDoc.uri, new vscode.Range(startPos, endPos), replacement);
+        await vscode.workspace.applyEdit(edit);
+        await this.ctrl.ui.saveDocument(weeklyDoc);
+        return true;
+    }
+}

--- a/src/provider/features/weekly-entry-watcher.ts
+++ b/src/provider/features/weekly-entry-watcher.ts
@@ -1,0 +1,140 @@
+import * as vscode from 'vscode';
+import * as J from '../..';
+import { getDatesOfISOWeek } from '../../util/dates';
+import { getWeekFromURIAndConfig } from '../../util/paths';
+import { SyncDailyLinks } from './sync-daily-links';
+
+/**
+ * Listens for active-editor changes and maintains a narrow FileSystemWatcher
+ * over the seven daily-entry paths of the currently active weekly file.
+ * FS events are debounced (500 ms) before triggering SyncDailyLinks.sync.
+ * Disposed alongside the extension when pushed onto context.subscriptions.
+ */
+export class WeeklyEntryWatcher implements vscode.Disposable {
+
+    private activeWatcher: vscode.FileSystemWatcher | undefined;
+    private activeUri: string | undefined;
+    private debounceHandle: ReturnType<typeof setTimeout> | undefined;
+    private readonly editorListener: vscode.Disposable;
+
+    constructor(
+        public ctrl: J.Util.Ctrl,
+        public sync: SyncDailyLinks
+    ) {
+        this.editorListener = vscode.window.onDidChangeActiveTextEditor(
+            e => this.handleEditorChange(e)
+        );
+        // Handle whatever is already open when the watcher is created.
+        this.handleEditorChange(vscode.window.activeTextEditor);
+    }
+
+    public dispose(): void {
+        this.clearDebounce();
+        this.disposeActiveWatcher();
+        this.editorListener.dispose();
+    }
+
+    private async handleEditorChange(
+        editor: vscode.TextEditor | undefined
+    ): Promise<void> {
+        if (!editor) {
+            this.disposeActiveWatcher();
+            return;
+        }
+
+        const weekInfo = await getWeekFromURIAndConfig(
+            editor.document.uri,
+            this.ctrl.config
+        );
+        if (!weekInfo) {
+            this.disposeActiveWatcher();
+            return;
+        }
+
+        const uriStr = editor.document.uri.toString();
+        if (uriStr === this.activeUri) {
+            return; // Same weekly file regained focus — watcher still valid.
+        }
+
+        this.disposeActiveWatcher();
+        this.activeUri = uriStr;
+
+        const { week, year, scope } = weekInfo;
+
+        // Register a watcher scoped to the 7 daily file paths of this week.
+        this.registerDailyWatcher(editor.document, week, year, scope);
+
+        // Initial sync on open.
+        this.sync.sync(editor.document, week, year, scope === 'default' ? undefined : scope)
+            .catch(err => this.ctrl.logger.error("WeeklyEntryWatcher: initial sync failed:", err));
+    }
+
+    private async registerDailyWatcher(
+        weeklyDoc: vscode.TextDocument,
+        week: number,
+        year: number,
+        scope: string
+    ): Promise<void> {
+        const scopeId = scope === 'default' ? undefined : scope;
+        const dates = getDatesOfISOWeek(week, year);
+
+        // Resolve all seven daily entry paths.
+        const patterns: string[] = [];
+        for (const date of dates) {
+            const pathTpl = await this.ctrl.config.getResolvedEntryPath(date, scopeId);
+            const fileTpl = await this.ctrl.config.getEntryFilePattern(date, scopeId);
+            if (pathTpl.value && fileTpl.value) {
+                // Use individual file globs — narrowest possible scope for performance.
+                patterns.push(pathTpl.value + '/' + fileTpl.value);
+            }
+        }
+
+        if (patterns.length === 0) { return; }
+
+        // VSCode does not support multi-pattern FileSystemWatcher natively, so we
+        // register one watcher per day and merge their events via the shared debounce.
+        const disposables: vscode.Disposable[] = [];
+        for (const pattern of patterns) {
+            const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+            const handler = () => this.scheduleSync(weeklyDoc, week, year, scopeId);
+            disposables.push(
+                watcher.onDidCreate(handler),
+                watcher.onDidChange(handler),
+                watcher.onDidDelete(handler),
+                watcher
+            );
+        }
+
+        // Wrap all disposables into a single composite disposable.
+        this.activeWatcher = { dispose: () => disposables.forEach(d => d.dispose()) } as vscode.FileSystemWatcher;
+    }
+
+    private scheduleSync(
+        doc: vscode.TextDocument,
+        week: number,
+        year: number,
+        scope?: string
+    ): void {
+        this.clearDebounce();
+        this.debounceHandle = setTimeout(() => {
+            this.sync.sync(doc, week, year, scope)
+                .catch(err => this.ctrl.logger.error("WeeklyEntryWatcher: debounced sync failed:", err));
+        }, 500);
+    }
+
+    private clearDebounce(): void {
+        if (this.debounceHandle !== undefined) {
+            clearTimeout(this.debounceHandle);
+            this.debounceHandle = undefined;
+        }
+    }
+
+    private disposeActiveWatcher(): void {
+        this.clearDebounce();
+        if (this.activeWatcher) {
+            this.activeWatcher.dispose();
+            this.activeWatcher = undefined;
+        }
+        this.activeUri = undefined;
+    }
+}

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,5 +1,7 @@
 export { MatchInput } from './features/match-input';
 export { SyncNoteLinks } from './features/sync-note-links';
+export { SyncDailyLinks } from './features/sync-daily-links';
+export { WeeklyEntryWatcher } from './features/weekly-entry-watcher';
 export { LoadNotes } from './features/load-note';
 export { ScanEntries, sortPickEntries } from './features/scan-entries';
 

--- a/src/test/suite/issue-168-entry-granularity.test.ts
+++ b/src/test/suite/issue-168-entry-granularity.test.ts
@@ -1,0 +1,234 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import moment = require('moment');
+import * as J from '../..';
+import { TestLogger } from '../test-logger';
+import { MatchInput } from '../../provider/features/match-input';
+
+async function setBase(tmpBase: string): Promise<void> {
+    const config = vscode.workspace.getConfiguration('journal');
+    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+}
+
+async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
+    const refreshed = vscode.workspace.getConfiguration('journal');
+    const ctrl = new J.Util.Ctrl(refreshed);
+    const logger = new TestLogger(false);
+    ctrl.logger = logger;
+    return { ctrl, logger };
+}
+
+suite('Issue #168 — Entry granularity', () => {
+
+    suite('Configuration.getEntryGranularity', () => {
+        let originalGranularity: string | undefined;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalGranularity = config.get<string>('entryGranularity');
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('entryGranularity', originalGranularity, vscode.ConfigurationTarget.Workspace);
+        });
+
+        test('defaults to "daily" when setting is unset', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('entryGranularity', undefined, vscode.ConfigurationTarget.Workspace);
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(refreshed);
+            assert.strictEqual(conf.getEntryGranularity(), 'daily');
+        });
+
+        test('returns "weekly" when setting is "weekly"', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('entryGranularity', 'weekly', vscode.ConfigurationTarget.Workspace);
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(refreshed);
+            assert.strictEqual(conf.getEntryGranularity(), 'weekly');
+        });
+
+        test('returns "daily" for any unknown value (defensive)', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('entryGranularity', 'monthly', vscode.ConfigurationTarget.Workspace);
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(refreshed);
+            assert.strictEqual(conf.getEntryGranularity(), 'daily');
+        });
+    });
+
+    suite('MatchInput granularity behavior', () => {
+        let logger: TestLogger;
+        const locale = 'en';
+
+        setup(() => {
+            logger = new TestLogger(false);
+        });
+
+        test('granularity=daily: bare "memo: buy milk" → offset=0, week=-1, hasWeek()=false', async () => {
+            const matcher = new MatchInput(logger, locale, 'daily');
+            const parsed = await matcher.parseInput('memo: buy milk');
+            assert.strictEqual(parsed.flags, 'memo');
+            assert.strictEqual(parsed.offset, 0);
+            assert.strictEqual(parsed.hasWeek(), false);
+        });
+
+        test('granularity=weekly: bare "memo: buy milk" → week=currentISOWeek, hasOffset()=false', async () => {
+            const matcher = new MatchInput(logger, locale, 'weekly');
+            const parsed = await matcher.parseInput('memo: buy milk');
+            assert.strictEqual(parsed.flags, 'memo');
+            assert.strictEqual(parsed.hasWeek(), true, 'expected hasWeek()=true under weekly granularity');
+            assert.strictEqual(parsed.week, moment().week(),
+                `expected week=${moment().week()}, got ${parsed.week}`);
+            assert.strictEqual(parsed.hasOffset(), false,
+                'expected hasOffset()=false so reader routes to weekly');
+        });
+
+        test('granularity=weekly: explicit "+0 task fix bug" still routes to today (explicit wins)', async () => {
+            const matcher = new MatchInput(logger, locale, 'weekly');
+            const parsed = await matcher.parseInput('+0 task fix bug');
+            assert.strictEqual(parsed.flags, 'task');
+            assert.strictEqual(parsed.offset, 0);
+            assert.strictEqual(parsed.hasWeek(), false,
+                'explicit +0 must not be coerced into a week');
+        });
+
+        test('granularity=weekly: explicit "w20 task plan release" still routes to week 20', async () => {
+            const matcher = new MatchInput(logger, locale, 'weekly');
+            const parsed = await matcher.parseInput('w20 task plan release');
+            assert.strictEqual(parsed.flags, 'task');
+            assert.strictEqual(parsed.hasWeek(), true);
+            assert.strictEqual(parsed.week, 20);
+        });
+
+        test('granularity=daily: explicit "w20 task plan release" still routes to week 20 (regression)', async () => {
+            const matcher = new MatchInput(logger, locale, 'daily');
+            const parsed = await matcher.parseInput('w20 task plan release');
+            assert.strictEqual(parsed.flags, 'task');
+            assert.strictEqual(parsed.hasWeek(), true);
+            assert.strictEqual(parsed.week, 20);
+        });
+
+        test('granularity=weekly: explicit "yesterday memo: shopping" still routes to yesterday', async () => {
+            const matcher = new MatchInput(logger, locale, 'weekly');
+            const parsed = await matcher.parseInput('yesterday memo: shopping');
+            assert.strictEqual(parsed.flags, 'memo');
+            assert.strictEqual(parsed.offset, -1);
+            assert.strictEqual(parsed.hasWeek(), false);
+        });
+    });
+
+    suite('Default weekly template includes section anchors', () => {
+        test('getWeeklyTemplate renders ## Tasks and ## Notes sections', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(config);
+            const tpl = await conf.getWeeklyTemplate(7);
+            assert.ok(tpl.value, 'template value should be set');
+            assert.ok(tpl.value!.includes('# Week 7'), `expected '# Week 7' in: ${tpl.value}`);
+            assert.ok(tpl.value!.includes('## Tasks'), `expected '## Tasks' anchor in: ${tpl.value}`);
+            assert.ok(tpl.value!.includes('## Notes'), `expected '## Notes' anchor in: ${tpl.value}`);
+        });
+    });
+
+    suite('Configuration.getResolvedWeeklyNotesPath', () => {
+        let originalBase: string | undefined;
+        let tmpBase: string;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            tmpBase = path.join(os.tmpdir(), `issue168-${Date.now()}`);
+            await setBase(tmpBase);
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+        });
+
+        test('resolves the default weekly notes path with year and week substituted', async () => {
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(refreshed);
+
+            const resolved = await conf.getResolvedWeeklyNotesPath(20, 2026);
+            assert.ok(resolved.value, 'resolved value should be set');
+            assert.ok(resolved.value!.includes('2026'),
+                `expected year '2026' in path: ${resolved.value}`);
+            assert.ok(resolved.value!.includes('w20'),
+                `expected 'w20' in path: ${resolved.value}`);
+            assert.ok(resolved.value!.startsWith(tmpBase),
+                `expected path under base ${tmpBase}, got ${resolved.value}`);
+        });
+
+        test('weekly notes file pattern substitutes input', async () => {
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(refreshed);
+
+            const filePattern = await conf.getWeeklyNotesFilePattern(20, 2026, 'My_Note');
+            assert.ok(filePattern.value, 'file pattern value should be set');
+            assert.ok(filePattern.value!.startsWith('My_Note'),
+                `expected filename to start with 'My_Note', got ${filePattern.value}`);
+            assert.ok(filePattern.value!.endsWith('.md'),
+                `expected '.md' extension, got ${filePattern.value}`);
+        });
+    });
+
+    suite('Parser.resolveNotePathForInput honors granularity', () => {
+        let originalBase: string | undefined;
+        let originalGranularity: string | undefined;
+        let tmpBase: string;
+        let ctrl: J.Util.Ctrl;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            originalGranularity = config.get<string>('entryGranularity');
+            tmpBase = path.join(os.tmpdir(), `issue168-notes-${Date.now()}`);
+            await setBase(tmpBase);
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+            await config.update('entryGranularity', originalGranularity, vscode.ConfigurationTarget.Workspace);
+        });
+
+        test('granularity=daily: notes path uses day-keyed pattern (regression)', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('entryGranularity', 'daily', vscode.ConfigurationTarget.Workspace);
+            ({ ctrl } = await buildCtrl());
+
+            const input = new J.Model.Input(0);
+            input.text = 'My_Note';
+            const resolvedPath = await ctrl.parser.resolveNotePathForInput(input);
+            const today = new Date();
+            const yy = String(today.getFullYear());
+            const mm = String(today.getMonth() + 1).padStart(2, '0');
+            const dd = String(today.getDate()).padStart(2, '0');
+            assert.ok(resolvedPath.includes(path.join(yy, mm, dd)),
+                `expected day-keyed path ${yy}/${mm}/${dd}, got ${resolvedPath}`);
+        });
+
+        test('granularity=weekly: notes path uses week-keyed pattern', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('entryGranularity', 'weekly', vscode.ConfigurationTarget.Workspace);
+            ({ ctrl } = await buildCtrl());
+
+            const input = new J.Model.Input(0);
+            input.text = 'My_Note';
+            const resolvedPath = await ctrl.parser.resolveNotePathForInput(input);
+            const today = new Date();
+            const expectedWeek = `w${moment(today).week()}`;
+            const expectedYear = String(moment(today).weekYear());
+            assert.ok(resolvedPath.includes(expectedWeek),
+                `expected week segment ${expectedWeek}, got ${resolvedPath}`);
+            assert.ok(resolvedPath.includes(expectedYear),
+                `expected year ${expectedYear}, got ${resolvedPath}`);
+            assert.ok(resolvedPath.includes('My_Note'),
+                `expected filename in path, got ${resolvedPath}`);
+        });
+    });
+});

--- a/src/test/suite/issue-185-weekly-sync.test.ts
+++ b/src/test/suite/issue-185-weekly-sync.test.ts
@@ -1,0 +1,326 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import moment = require('moment');
+import * as J from '../..';
+import { SyncDailyLinks } from '../../provider/features/sync-daily-links';
+import { getWeekFromURIAndConfig } from '../../util/paths';
+import { getDatesOfISOWeek } from '../../util/dates';
+import { TestLogger } from '../test-logger';
+
+async function setBase(tmpBase: string): Promise<void> {
+    const config = vscode.workspace.getConfiguration('journal');
+    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+}
+
+async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
+    const refreshed = vscode.workspace.getConfiguration('journal');
+    const ctrl = new J.Util.Ctrl(refreshed);
+    const logger = new TestLogger(false);
+    ctrl.logger = logger;
+    return { ctrl, logger };
+}
+
+async function writeFile(uri: vscode.Uri, content = ''): Promise<void> {
+    await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+}
+
+async function readFile(uri: vscode.Uri): Promise<string> {
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return new TextDecoder().decode(bytes);
+}
+
+suite('Issue #185 — Weekly daily-link sync', () => {
+
+    suite('getDatesOfISOWeek', () => {
+        test('returns 7 dates starting from Monday of the given week', () => {
+            const dates = getDatesOfISOWeek(20, 2026);
+            assert.strictEqual(dates.length, 7, 'expected 7 dates');
+
+            const mon = moment(dates[0]);
+            assert.strictEqual(mon.week(), 20, `expected week 20, got ${mon.week()}`);
+            assert.strictEqual(mon.weekYear(), 2026, `expected weekYear 2026, got ${mon.weekYear()}`);
+
+            // Days are consecutive.
+            for (let i = 1; i < 7; i++) {
+                const diff = moment(dates[i]).diff(moment(dates[i - 1]), 'days');
+                assert.strictEqual(diff, 1, `days[${i}] should be 1 day after days[${i - 1}]`);
+            }
+        });
+    });
+
+    suite('URI helper — getWeekFromURIAndConfig', () => {
+        let originalBase: string | undefined;
+        let tmpBase: string;
+        let ctrl: J.Util.Ctrl;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            tmpBase = path.join(os.tmpdir(), `issue185-uri-${Date.now()}`);
+            await setBase(tmpBase);
+            ({ ctrl } = await buildCtrl());
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+        });
+
+        test('recognizes default weekly path and extracts week + year', async () => {
+            // Default weeks.file = "week_${week}.${ext}", path = "${base}/${year}"
+            // → e.g. <base>/2026/week_20.md
+            const weeklyPath = path.join(tmpBase, '2026', 'week_20.md');
+            const uri = vscode.Uri.file(weeklyPath);
+            const result = await getWeekFromURIAndConfig(uri, ctrl.config);
+            assert.ok(result, 'expected a match');
+            assert.strictEqual(result!.week, 20);
+            assert.strictEqual(result!.year, 2026);
+            assert.strictEqual(result!.scope, 'default');
+        });
+
+        test('returns undefined for a daily entry URI', async () => {
+            const dailyPath = path.join(tmpBase, '2026', '05', '14.md');
+            const uri = vscode.Uri.file(dailyPath);
+            const result = await getWeekFromURIAndConfig(uri, ctrl.config);
+            assert.strictEqual(result, undefined);
+        });
+
+        test('returns undefined for a completely unrelated file', async () => {
+            const uri = vscode.Uri.file('/tmp/some-other-file.md');
+            const result = await getWeekFromURIAndConfig(uri, ctrl.config);
+            assert.strictEqual(result, undefined);
+        });
+    });
+
+    suite('Configuration.getWeeklySyncConfig', () => {
+        test('returns defaults when setting is unset', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(config);
+            const syncCfg = conf.getWeeklySyncConfig();
+            assert.strictEqual(syncCfg.enabled, true);
+            assert.strictEqual(syncCfg.anchor, '## Daily Entries');
+            assert.strictEqual(syncCfg.template, '- [${weekday}, ${d:MMMM DD}](${link})');
+            assert.strictEqual(syncCfg.sortOrder, 'ascending');
+        });
+    });
+
+    suite('SyncDailyLinks — rendering (unit)', () => {
+        let originalBase: string | undefined;
+        let tmpBase: string;
+        let ctrl: J.Util.Ctrl;
+        let weeklyUri: vscode.Uri;
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            tmpBase = path.join(os.tmpdir(), `issue185-render-${Date.now()}`);
+            await setBase(tmpBase);
+            ({ ctrl } = await buildCtrl());
+
+            // Create the weekly file placeholder (content irrelevant for rendering unit test).
+            weeklyUri = vscode.Uri.file(path.join(tmpBase, '2026', 'week_20.md'));
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026')));
+            await writeFile(weeklyUri, '# Week 20\n\n## Daily Entries\n\n');
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+        });
+
+        test('renderBlock produces one line per URI in ascending order', async () => {
+            // Seed Mon (2026-05-11) and Wed (2026-05-13) of week 20.
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
+            const wedUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '13.md'));
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026', '05')));
+            await writeFile(monUri, '');
+            await writeFile(wedUri, '');
+
+            const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
+            const syncer = new SyncDailyLinks(ctrl);
+            const block = await syncer.renderBlock(weeklyDoc, [monUri, wedUri]);
+
+            const lines = block.split('\n').filter(l => l.length > 0);
+            assert.strictEqual(lines.length, 2, 'expected 2 link lines');
+            // Both lines should start with the link bullet.
+            assert.ok(lines[0].startsWith('- ['), `line 0: ${lines[0]}`);
+            assert.ok(lines[1].startsWith('- ['), `line 1: ${lines[1]}`);
+
+            // Links should be relative paths.
+            assert.ok(lines[0].includes('05/11.md'), `line 0 should link to 05/11.md: ${lines[0]}`);
+            assert.ok(lines[1].includes('05/13.md'), `line 1 should link to 05/13.md: ${lines[1]}`);
+        });
+
+        test('renderBlock respects sortOrder=descending', async () => {
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
+            const friUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '15.md'));
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026', '05')));
+            await writeFile(monUri, '');
+            await writeFile(friUri, '');
+
+            // Override weeklySync to descending.
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('weeklySync', { enabled: true, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'descending' }, vscode.ConfigurationTarget.Workspace);
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const descCtrl = new J.Util.Ctrl(refreshed);
+            descCtrl.logger = ctrl.logger;
+
+            try {
+                const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
+                const syncer = new SyncDailyLinks(descCtrl);
+                const block = await syncer.renderBlock(weeklyDoc, [monUri, friUri]);
+                const lines = block.split('\n').filter(l => l.length > 0);
+                // Descending → Friday first.
+                assert.ok(lines[0].includes('05/15.md'), `first line should be Friday: ${lines[0]}`);
+                assert.ok(lines[1].includes('05/11.md'), `second line should be Monday: ${lines[1]}`);
+            } finally {
+                await config.update('weeklySync', undefined, vscode.ConfigurationTarget.Workspace);
+            }
+        });
+    });
+
+    suite('SyncDailyLinks — integration', () => {
+        let originalBase: string | undefined;
+        let tmpBase: string;
+        let ctrl: J.Util.Ctrl;
+        let logger: TestLogger;
+        let weeklyUri: vscode.Uri;
+        const weeklyContent = '# Week 20\n\n## Daily Entries\n\n## Notes\n\n';
+
+        setup(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            originalBase = config.get<string>('base');
+            tmpBase = path.join(os.tmpdir(), `issue185-integ-${Date.now()}`);
+            await setBase(tmpBase);
+            ({ ctrl, logger } = await buildCtrl());
+
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026')));
+            await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026', '05')));
+
+            weeklyUri = vscode.Uri.file(path.join(tmpBase, '2026', 'week_20.md'));
+            await writeFile(weeklyUri, weeklyContent);
+        });
+
+        teardown(async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+        });
+
+        test('W8 — golden path: sync injects links for existing daily entries', async () => {
+            // Seed Mon + Wed + Fri of week 20, 2026.
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
+            const wedUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '13.md'));
+            const friUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '15.md'));
+            await writeFile(monUri, '');
+            await writeFile(wedUri, '');
+            await writeFile(friUri, '');
+
+            const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
+            const syncer = new SyncDailyLinks(ctrl);
+            await syncer.sync(weeklyDoc, 20, 2026);
+
+            const result = await readFile(weeklyUri);
+            assert.ok(result.includes('05/11.md'), `Mon link expected: ${result}`);
+            assert.ok(result.includes('05/13.md'), `Wed link expected: ${result}`);
+            assert.ok(result.includes('05/15.md'), `Fri link expected: ${result}`);
+            assert.ok(result.includes('## Daily Entries'), 'anchor must still be present');
+            assert.ok(result.includes('## Notes'), 'next heading must still be present');
+            assert.strictEqual(logger.errors.length, 0, 'no errors expected');
+        });
+
+        test('W9 — idempotent: second sync with no FS changes produces no edit', async () => {
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
+            await writeFile(monUri, '');
+
+            const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
+            const syncer = new SyncDailyLinks(ctrl);
+            await syncer.sync(weeklyDoc, 20, 2026);
+
+            const after1 = await readFile(weeklyUri);
+            // Second sync on the (now modified) document.
+            const doc2 = await vscode.workspace.openTextDocument(weeklyUri);
+            const applied2 = await syncer.applyBlock(
+                doc2,
+                '## Daily Entries',
+                await syncer.renderBlock(doc2, await syncer.findDailyEntriesForWeek(20, 2026))
+            );
+            assert.strictEqual(applied2, false, 'second apply should be a no-op');
+            const after2 = await readFile(weeklyUri);
+            assert.strictEqual(after2, after1, 'content must not change on second sync');
+        });
+
+        test('W10 — missing anchor: sync skips silently', async () => {
+            const noAnchorUri = vscode.Uri.file(path.join(tmpBase, '2026', 'week_21.md'));
+            await writeFile(noAnchorUri, '# Week 21\n\n## Tasks\n\n## Notes\n\n');
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '18.md'));
+            await writeFile(monUri, '');
+
+            const doc = await vscode.workspace.openTextDocument(noAnchorUri);
+            const syncer = new SyncDailyLinks(ctrl);
+            const applied = await syncer.applyBlock(doc, '## Daily Entries', '- [Monday, May 18](05/18.md)');
+            assert.strictEqual(applied, false, 'should skip when anchor is missing');
+            assert.strictEqual(logger.errors.length, 0, 'no errors on missing anchor');
+        });
+
+        test('W11 — enabled=false: sync respects setting', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            await config.update('weeklySync', { enabled: false, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'ascending' }, vscode.ConfigurationTarget.Workspace);
+            const refreshed = vscode.workspace.getConfiguration('journal');
+            const disabledCtrl = new J.Util.Ctrl(refreshed);
+            disabledCtrl.logger = logger;
+
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
+            await writeFile(monUri, '');
+
+            try {
+                const doc = await vscode.workspace.openTextDocument(weeklyUri);
+                const syncer = new SyncDailyLinks(disabledCtrl);
+                await syncer.sync(doc, 20, 2026);
+                const result = await readFile(weeklyUri);
+                assert.strictEqual(result, weeklyContent, 'file must be untouched when disabled');
+            } finally {
+                await config.update('weeklySync', undefined, vscode.ConfigurationTarget.Workspace);
+            }
+        });
+
+        test('W5 — findDailyEntriesForWeek returns existing URIs only, ascending', async () => {
+            // Seed only Mon and Fri; leave rest absent.
+            const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
+            const friUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '15.md'));
+            await writeFile(monUri, '');
+            await writeFile(friUri, '');
+
+            const syncer = new SyncDailyLinks(ctrl);
+            const found = await syncer.findDailyEntriesForWeek(20, 2026);
+            assert.strictEqual(found.length, 2, 'expected exactly 2 existing daily files');
+            // Ascending order means Mon before Fri.
+            assert.ok(found[0].fsPath.endsWith('11.md'), `first should be Mon: ${found[0].fsPath}`);
+            assert.ok(found[1].fsPath.endsWith('15.md'), `second should be Fri: ${found[1].fsPath}`);
+        });
+    });
+
+    suite('Default weekly template includes ## Daily Entries', () => {
+        test('W16 — getWeeklyTemplate includes ## Daily Entries anchor', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(config);
+            const tpl = await conf.getWeeklyTemplate(20);
+            assert.ok(tpl.value, 'template value should be set');
+            assert.ok(tpl.value!.includes('## Daily Entries'),
+                `expected '## Daily Entries' in: ${tpl.value}`);
+        });
+    });
+
+    suite('W17 — #168 regression assertions remain green', () => {
+        test('existing weekly template test still passes', async () => {
+            const config = vscode.workspace.getConfiguration('journal');
+            const conf = new J.Extension.Configuration(config);
+            const tpl = await conf.getWeeklyTemplate(7);
+            assert.ok(tpl.value, 'template value should be set');
+            assert.ok(tpl.value!.includes('# Week 7'), `expected '# Week 7' in: ${tpl.value}`);
+            assert.ok(tpl.value!.includes('## Tasks'), `expected '## Tasks' anchor in: ${tpl.value}`);
+            assert.ok(tpl.value!.includes('## Notes'), `expected '## Notes' anchor in: ${tpl.value}`);
+        });
+    });
+});

--- a/src/util/dates.ts
+++ b/src/util/dates.ts
@@ -42,6 +42,19 @@ export function getISOWeekYear(date: Date): number {
 }
 
 /**
+ * Returns the 7 Date objects (Mon → Sun) for the given week/year pair, using
+ * the same locale-aware week convention as getCurrentISOWeek and getISOWeekYear.
+ */
+export function getDatesOfISOWeek(week: number, year: number): Date[] {
+    const startOfWeek = moment().week(week).weekYear(year).startOf("week");
+    const dates: Date[] = [];
+    for (let i = 0; i < 7; i++) {
+        dates.push(moment(startOfWeek).add(i, "days").toDate());
+    }
+    return dates;
+}
+
+/**
 * Formats a given Date in long format (for Header in journal pages)
 */
 export function formatDate(date: Date, template: string, locale: string): string {

--- a/src/util/dates.ts
+++ b/src/util/dates.ts
@@ -24,6 +24,24 @@ import moment = require("moment");
 
 
 /**
+ * Returns the ISO week number for the given date using the same backing
+ * library (moment.js) as the rest of the codebase, so values stay
+ * consistent with the `${week}` template variable and weekly path resolution.
+ */
+export function getCurrentISOWeek(date: Date): number {
+    return moment(date).week();
+}
+
+/**
+ * Returns the year associated with the ISO week of the given date. For
+ * dates in the first or last week of the year, this may differ from the
+ * calendar year (e.g. 2024-12-30 belongs to ISO week 1 of 2025).
+ */
+export function getISOWeekYear(date: Date): number {
+    return moment(date).weekYear();
+}
+
+/**
 * Formats a given Date in long format (for Header in journal pages)
 */
 export function formatDate(date: Date, template: string, locale: string): string {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -26,7 +26,9 @@ export {
 } from './util';
 export {
     formatDate,
+    getCurrentISOWeek,
     getDayOfWeekForString,
+    getISOWeekYear,
     getMonthForString,
     replaceDateFormats,
     replaceDateTemplatesWithMomentsFormats,

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -27,6 +27,7 @@ export {
 export {
     formatDate,
     getCurrentISOWeek,
+    getDatesOfISOWeek,
     getDayOfWeekForString,
     getISOWeekYear,
     getMonthForString,
@@ -51,6 +52,7 @@ export {
     getFilePathInDateFolder,
     getPathAsString,
     getPathOfMonth,
+    getWeekFromURIAndConfig,
     inferType,
     resolvePath,
 } from './paths';

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -201,12 +201,67 @@ export function inferType(entry: Path.ParsedPath, extension: string): J.Model.Jo
 
 
 /**
- * Converts given path and filename into a full path. 
- * @param pathname 
- * @param filename 
+ * Converts given path and filename into a full path.
+ * @param pathname
+ * @param filename
  */
 export function resolvePath(pathname: string, filename: string): string {
 
     return Path.join(pathname, filename);
 
+}
+
+/**
+ * Tries to infer the week number, year, and scope from a weekly file URI by matching
+ * the URI against the configured weeks path+file patterns for each known scope.
+ *
+ * Pattern variables supported: ${base}, ${year} → (\d{4}), ${week} → (\d{1,2}), ${ext}.
+ * Returns undefined when no configured scope matches the URI.
+ */
+export async function getWeekFromURIAndConfig(
+    uri: vscode.Uri,
+    config: J.Extension.Configuration
+): Promise<{ week: number; year: number; scope: string } | undefined> {
+    const ext = config.getFileExtension();
+    const escapedExt = ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const uriPath = uri.fsPath.replace(/\\/g, '/');
+
+    for (const scope of config.getScopes()) {
+        const scopeId = scope === 'default' ? undefined : scope;
+        const base = config.getBasePath(scopeId);
+        const pathTpl = config.getWeeksPathPatternRaw(scopeId);
+        const fileTpl = config.getWeeksFilePatternRaw(scopeId);
+
+        const fullTpl = pathTpl + '/' + fileTpl;
+
+        // Normalize the base path to forward slashes first (Windows path support),
+        // then escape it as a regex literal.
+        const normalizedBase = base.replace(/\\/g, '/');
+        const escapedBase = normalizedBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+        // Replace template vars with regex capture groups. Do NOT apply blanket
+        // backslash normalization after this step — it would corrupt \d sequences.
+        const regexStr = fullTpl
+            .replace(/\$\{base\}/g, escapedBase)
+            .replace(/\$\{year\}/g, '(\\d{4})')
+            .replace(/\$\{week\}/g, '(\\d{1,2})')
+            .replace(/\$\{ext\}/g, escapedExt);
+
+        // Track which capture group corresponds to year vs week.
+        const yearFirst = fullTpl.indexOf('${year}') < fullTpl.indexOf('${week}');
+
+        try {
+            const regex = new RegExp(regexStr + '$');
+            const match = uriPath.match(regex);
+            if (match) {
+                const year  = parseInt(yearFirst ? match[1] : match[2], 10);
+                const week  = parseInt(yearFirst ? match[2] : match[1], 10);
+                return { week, year, scope };
+            }
+        } catch {
+            // Malformed regex from an unusual pattern — skip this scope.
+        }
+    }
+
+    return undefined;
 }


### PR DESCRIPTION
## Summary

- **Fixes #168** — New `journal.entryGranularity` setting (`daily` default / `weekly`) routes quick memos, tasks, and notes to the current ISO week's weekly entry when no explicit date target is given. Explicit input (offset, ISO date, weekday, week number) always wins.
- **Fixes #185** — When a weekly entry is the active editor, `SyncDailyLinks` + `WeeklyEntryWatcher` automatically maintain a `## Daily Entries` block with links to every daily file in the same ISO week. Sync fires on open and on narrow per-day `FileSystemWatcher` events (500 ms debounce). Idempotent: no edit when content is already correct.

## Changes

- `journal.entryGranularity` setting + `MatchInput` granularity-aware routing
- `journal.patterns.weeklyNotes` pattern for weekly notes path
- `journal.weeklySync` config block (`enabled`, `anchor`, `template`, `sortOrder`)
- Default `weekly` template updated: `## Tasks` + `## Notes` + `## Daily Entries`
- New `dailyLink` template entry in `journal.templates` defaults
- `getDatesOfISOWeek(week, year)` date utility
- `getWeekFromURIAndConfig(uri, config)` URI → week/year/scope resolver
- `SyncDailyLinks` — finds daily URIs, renders link block, applies idempotent block replace + save
- `WeeklyEntryWatcher` — editor listener with per-day FS watcher, 500 ms debounce, full dispose
- Wire-in: `Startup.registerCommands` (watcher lifecycle) + `loadPageForInput` (sync on open, fire-and-forget)
- 14 new tests (99/99 suite green)
- Docs: `docs/settings.md` Weekly Sync section; CHANGELOG entries for both issues

## Test plan

- [ ] `npm run check` passes (lint + compile + 99 tests)
- [ ] Open a daily entry for a week that has a weekly file → no change to weekly file (daily URIs don't match week pattern)
- [ ] Open a weekly file where 3 daily entries exist → `## Daily Entries` block populated with 3 links
- [ ] Re-open the same weekly file → no edit (idempotent)
- [ ] Create a new daily file while weekly is active → link appears within ~600ms
- [ ] Delete a daily file while weekly is active → link removed within ~600ms
- [ ] Set `journal.weeklySync.enabled = false` → no sync, no watcher registered
- [ ] Weekly file without `## Daily Entries` → silently skipped (debug log, no error toast)
- [ ] Set `journal.entryGranularity = "weekly"` → bare memo input routes to current week's weekly entry
- [ ] Explicit `+0 memo: text` with `entryGranularity = "weekly"` → still goes to today

🤖 Generated with [Claude Code](https://claude.com/claude-code)