### PR TITLE
perf: input box cold-start + cache short-circuit (#187)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ src/*.js
 test/workspace
 test/test
 .vscode-test
+
+# Maintainer-local Claude Code memory; shared guidance lives in AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Project-level guidance for any AI coding assistant (Claude Code, Codex, Gemini CLI, Copilot CLI, etc.) and for humans contributing to this repository.
 
 ## Project
 
@@ -24,6 +24,8 @@ Run a single test by passing a Mocha grep through `@vscode/test-cli`:
 ```bash
 npm test -- --grep "MatchInput"
 ```
+
+`--grep` is the fast TDD loop (~5 s vs 30 s for the full suite). `rm -rf out/` between branch switches — `npm run compile-tests` does not prune stale `.test.js` files, so deleted/renamed tests keep running and show as phantom failures when comparing test counts across branches.
 
 Tests live in `src/test/suite/**/*.test.ts`, compile to `out/test/suite/**/*.test.js`, and run inside a real Extension Host against the workspace `test/ws_unittests/`. Mocha TDD UI, 20s default timeout (`.vscode-test.mjs`). `src/test/direct/` contains plain-node debug scripts, not part of the suite.
 
@@ -70,6 +72,8 @@ Entry: `src/extension.ts` → `Startup(config).run(context)` (in `src/ext/startu
 - ESLint flat config (`eslint.config.mjs`) enforces `curly`, `eqeqeq`, `no-throw-literal`, `semi`. Import naming must be `camelCase` or `PascalCase`.
 - `tsconfig.json` runs `strict`, `noImplicitReturns`, `noFallthroughCasesInSwitch`. The bundle goes through esbuild, but tests are compiled via `tsc` — both must succeed for `npm test`.
 - `docs/` contains user-facing feature docs (entries, notes, memos, tasks, scopes, settings, codeactions) and `docs/analysis/` holds the analysis that produced `PLAN.md`.
+- Local `develop` often lags `origin/develop` — `git fetch origin develop` and rebase the feature branch before opening a PR. Remote branches created from the issue UI may already exist as empty refs; fetch and rebase rather than force-push.
+- Conventional Commits with scope: `perf(scan-entries):`, `feat(navigation):`, `fix(remote):`, `test(remote):`, `docs:`. Issue ref goes in the commit body (`#187`), not the subject.
 
 ## Testing patterns
 
@@ -77,6 +81,7 @@ Entry: `src/extension.ts` → `Startup(config).run(context)` (in `src/ext/startu
 - `TestLogger` (`src/test/test-logger.ts`) has an `errors[]` accumulator — assert `logger.errors.length === 0` to prove "no error logged on the happy path".
 - Don't call `Command.create(ctrl)` in tests — it re-registers the command and collides with activation. Instantiate directly: `new (Cmd as any)(ctrl)` then call the instance method.
 - Monkey-patch seams that work: `(ctrl.ui as any).openDocument = wrapper` and `(vscode.window as any).showInformationMessage = wrapper`. Restore in teardown.
+- `vscode.workspace.fs` is frozen — to observe FS calls, spy on the class method via prototype (`(ScanEntries.prototype as any).walkDir = function(...) { count++; return orig.apply(this, args); }`). Restore in teardown. See `scan-entries-cache.test.ts`.
 
 ## Reusable building blocks
 

--- a/src/ext/dialogues.ts
+++ b/src/ext/dialogues.ts
@@ -36,10 +36,14 @@ import { sortPickEntries } from '../provider';
  */
 export class Dialogues {
 
-    private scanner;
+    private scanner: J.Provider.ScanEntries;
 
     constructor(public ctrl: J.Util.Ctrl) {
         this.scanner = new J.Provider.ScanEntries(this.ctrl);
+    }
+
+    public getScanner(): J.Provider.ScanEntries {
+        return this.scanner;
     }
 
 
@@ -570,13 +574,35 @@ function addItemToPickList(entries: J.Model.FileEntry[], input: J.Model.TimedQui
             fileEntry: fe,
             description: displayDescription
         };
-        input.items = input.items.concat(item);
+        items.push(item);
 
     });
 
-
-    /* we have to sort the items list */
-    input.items = Array.from(input.items).sort((a, b) => sortPickEntries(a.fileEntry!, b.fileEntry!));
+    /* Sorted insertion into input.items via binary search (#187): avoids the O(n² log n)
+       cost of re-sorting the growing items array on every directory-level callback. */
+    if (items.length > 0) {
+        const merged = Array.from(input.items);
+        for (const item of items) {
+            if (!item.fileEntry) {
+                merged.push(item);
+                continue;
+            }
+            let lo = 0;
+            let hi = merged.length;
+            while (lo < hi) {
+                const mid = (lo + hi) >>> 1;
+                const midEntry = merged[mid].fileEntry;
+                // items without fileEntry (the placeholder rows) stay at the front
+                if (!midEntry || sortPickEntries(midEntry, item.fileEntry) <= 0) {
+                    lo = mid + 1;
+                } else {
+                    hi = mid;
+                }
+            }
+            merged.splice(lo, 0, item);
+        }
+        input.items = merged;
+    }
 
     /* Some voodoo to stop the spinner. Since it's a mess to find out when the recursive directory walker is finished, we simply finish after 3 seconds.  */
     if ((input.items.length > 20) || (((new Date().getTime()) - input.start!) > 3000)) {

--- a/src/ext/startup.ts
+++ b/src/ext/startup.ts
@@ -41,6 +41,7 @@ export class Startup {
             .then(() => this.registerCommands(this.ctrl, context))
             .then(() => this.registerCodeActions(this.ctrl, context))
             .then(() => this.registerSyntaxHighlighting(this.ctrl))
+            .then(() => this.registerCacheInvalidation(this.ctrl, context))
 
             .then((ctrl) => {
                 console.timeEnd("startup");
@@ -139,6 +140,15 @@ export class Startup {
             throw error;
         }
 
+    }
+
+    public async registerCacheInvalidation(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<void> {
+        try {
+            const scanner = ctrl.ui.getScanner();
+            context.subscriptions.push(...scanner.registerInvalidationListeners());
+        } catch (error) {
+            ctrl.logger.error("Failed to register cache invalidation listeners, reason: ", error);
+        }
     }
 
     public async registerCodeActions(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<void> {

--- a/src/provider/features/scan-entries.ts
+++ b/src/provider/features/scan-entries.ts
@@ -17,6 +17,13 @@ export class ScanEntries {
         this.cache = new Map();
     }
 
+    /**
+     * Discards cached entries so the next scan re-reads the filesystem.
+     */
+    public clearCache(): void {
+        this.cache.clear();
+    }
+
 
 
     /**
@@ -75,16 +82,18 @@ export class ScanEntries {
 
         this.ctrl.logger.trace("Entering getPreviouslyAccessedFiles() in actions/reader.ts and number of directories to scan: ", directories.size);
 
-        // we add everything from the cache 
+        // Cache short-circuit (#187): if we have already scanned, return cached entries and
+        // skip the filesystem walk entirely. Cache is invalidated explicitly via clearCache()
+        // — wire workspace file-event listeners through registerInvalidationListeners().
         if (this.cache.size > 0) {
             let cachedEntries: FileEntry[] = Array.from(this.cache.values()).filter(fe => fe.type === type).sort(sortPickEntries);
             callback(cachedEntries, picker, type);
+            return;
         }
-
 
         // we have to live with duplicates in the set of directories (which also means we have to live with non-deterministic scope resolution)
 
-        // we scan the scopes first 
+        // we scan the scopes first
         Array.from(directories)
             .filter(dir => dir.scope !== SCOPE_DEFAULT)
             .forEach(dir => this.scanDirectory(thresholdInMs, callback, picker, type, dir));
@@ -92,6 +101,17 @@ export class ScanEntries {
         Array.from(directories)
             .filter(dir => dir.scope === SCOPE_DEFAULT)
             .forEach(dir => this.scanDirectory(thresholdInMs, callback, picker, type, dir));
+    }
+
+    /**
+     * Registers workspace file-create/delete listeners that clear the cache so the next
+     * scan re-reads the filesystem. Caller (Startup) owns the returned disposables.
+     */
+    public registerInvalidationListeners(): vscode.Disposable[] {
+        const onCreate = vscode.workspace.onDidCreateFiles(() => this.clearCache());
+        const onDelete = vscode.workspace.onDidDeleteFiles(() => this.clearCache());
+        const onRename = vscode.workspace.onDidRenameFiles(() => this.clearCache());
+        return [onCreate, onDelete, onRename];
     }
 
 
@@ -139,31 +159,43 @@ export class ScanEntries {
             return; // ignore errors
         }
 
-        const foundFiles: FileEntry[] = [];
+        // Partition into files (need stat) and subdirectories (need recursion). Issue #187:
+        // stat calls are fanned out per directory level so remote filesystems do not pay
+        // sequential round-trip latency for every file.
+        const files: { name: string; childPath: string }[] = [];
+        const subdirs: string[] = [];
 
         for (const [name, type] of entries) {
             if (name.startsWith(".")) { continue; }
             const childPath = Path.join(dir, name);
-
             if (type === vscode.FileType.Directory) {
-                await this.walkDir(childPath, thresholdInMs, callback);
+                subdirs.push(childPath);
             } else {
-                try {
-                    const stat = await vscode.workspace.fs.stat(vscode.Uri.file(childPath));
-                    foundFiles.push({
-                        path: childPath,
-                        name: name,
-                        updateAt: stat.mtime,
-                        accessedAt: stat.mtime, // vscode.FileStat does not expose atime
-                        createdAt: stat.ctime
-                    });
-                } catch {
-                    // skip files we can't stat
-                }
+                files.push({ name, childPath });
             }
         }
 
+        const statResults = await Promise.all(
+            files.map(async ({ name, childPath }) => {
+                try {
+                    const stat = await vscode.workspace.fs.stat(vscode.Uri.file(childPath));
+                    return {
+                        path: childPath,
+                        name,
+                        updateAt: stat.mtime,
+                        accessedAt: stat.mtime, // vscode.FileStat does not expose atime
+                        createdAt: stat.ctime
+                    } as FileEntry;
+                } catch {
+                    return undefined;
+                }
+            })
+        );
+
+        const foundFiles: FileEntry[] = statResults.filter((f): f is FileEntry => f !== undefined);
         callback(foundFiles);
+
+        await Promise.all(subdirs.map(d => this.walkDir(d, thresholdInMs, callback)));
     }
 
     // deprecated — converted to async vscode.workspace.fs for remote compatibility

--- a/src/test/suite/scan-entries-cache.test.ts
+++ b/src/test/suite/scan-entries-cache.test.ts
@@ -1,0 +1,112 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as J from '../..';
+import { ScanEntries } from '../../provider/features/scan-entries';
+import { SCOPE_DEFAULT } from '../../ext';
+import { JournalPageType, ScopeDirectory } from '../../model';
+import { TestLogger } from '../test-logger';
+
+async function seedEntry(base: string, year: number, month: number, day: number, content = '# Entry\n'): Promise<void> {
+    const yy = String(year).padStart(4, '0');
+    const mm = String(month).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
+    const dir = vscode.Uri.file(path.join(base, yy, mm));
+    await vscode.workspace.fs.createDirectory(dir);
+    const file = vscode.Uri.file(path.join(base, yy, mm, `${dd}.md`));
+    await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(content));
+}
+
+suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
+    let originalBase: string | undefined;
+    let tmpBase: string;
+    let ctrl: J.Util.Ctrl;
+    let scanner: ScanEntries;
+    let walkCount: number;
+    let originalWalkDir: any;
+
+    setup(async () => {
+        const config = vscode.workspace.getConfiguration('journal');
+        originalBase = config.get<string>('base');
+
+        tmpBase = path.join(os.tmpdir(), `issue187-base-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
+        await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+
+        await seedEntry(tmpBase, 2025, 3, 5);
+        await seedEntry(tmpBase, 2025, 3, 8);
+        await seedEntry(tmpBase, 2025, 4, 1);
+
+        const refreshed = vscode.workspace.getConfiguration('journal');
+        ctrl = new J.Util.Ctrl(refreshed);
+        ctrl.logger = new TestLogger(false);
+        scanner = new ScanEntries(ctrl);
+
+        walkCount = 0;
+        originalWalkDir = (ScanEntries.prototype as any).walkDir;
+        (ScanEntries.prototype as any).walkDir = async function (dir: string, threshold: number, callback: Function): Promise<void> {
+            if (typeof dir === 'string' && dir.startsWith(tmpBase)) {
+                walkCount++;
+            }
+            return originalWalkDir.call(this, dir, threshold, callback);
+        };
+    });
+
+    teardown(async () => {
+        (ScanEntries.prototype as any).walkDir = originalWalkDir;
+        const config = vscode.workspace.getConfiguration('journal');
+        await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+        try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
+    });
+
+    async function runScan(): Promise<void> {
+        const directories = new Set<ScopeDirectory>([{ path: tmpBase, scope: SCOPE_DEFAULT }]);
+        let resolveDone: () => void = () => { /* set below */ };
+        const done = new Promise<void>(resolve => { resolveDone = resolve; });
+
+        let pendingDirs = 0;
+        let walkStarted = false;
+
+        const callback = (_entries: any[], _picker: any, _type: any) => {
+            // first callback signals at least one walk pass completed
+            if (!walkStarted) {
+                walkStarted = true;
+            }
+        };
+
+        await scanner.getPreviouslyAccessedFiles(Date.now() - 1000 * 60 * 60 * 24 * 365, callback as any, null, JournalPageType.entry, directories);
+        // scanDirectory is fire-and-forget inside getPreviouslyAccessedFiles; let the microtask queue drain
+        await new Promise(resolve => setTimeout(resolve, 100));
+        // silence unused warnings
+        void pendingDirs; void resolveDone; void done;
+    }
+
+    test('first scan walks the filesystem', async () => {
+        await runScan();
+        assert.ok(walkCount > 0, `expected ScanEntries.walkDir to run on first scan, got ${walkCount}`);
+    });
+
+    test('second scan with populated cache does NOT walk the filesystem', async () => {
+        await runScan();
+        const firstCount = walkCount;
+        assert.ok(firstCount > 0, 'precondition: first scan must have walked the FS');
+
+        walkCount = 0;
+        await runScan();
+
+        assert.strictEqual(walkCount, 0, `expected zero walkDir calls on cached scan, got ${walkCount}`);
+    });
+
+    test('clearCache() restores dirty state — next scan walks again', async () => {
+        await runScan();
+        assert.ok(walkCount > 0);
+
+        scanner.clearCache();
+
+        walkCount = 0;
+        await runScan();
+
+        assert.ok(walkCount > 0, `expected fresh walk after clearCache, got ${walkCount}`);
+    });
+});

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -17,7 +17,6 @@
 // 
 
 
-import moment = require('moment');
 import * as vscode from 'vscode';
 import * as J from '../.';
 
@@ -131,8 +130,12 @@ export class ConsoleLogger implements Logger {
 
 
     private appendCurrentTime() : void {
+        // HH:mm:ss.SSS — native to drop moment from the activation path (#187)
+        const d = new Date();
+        const pad = (n: number, w: number = 2) => String(n).padStart(w, '0');
+        const stamp = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
         this.channel.append("[");
-        this.channel.append(moment(new Date()).format('HH:mm:ss.SSS'));
+        this.channel.append(stamp);
         this.channel.append("]");
     }
 }


### PR DESCRIPTION
Closes #187.

## Summary

- **Cache short-circuit in `ScanEntries`** — `getPreviouslyAccessedFiles` now returns cached entries and skips the FS walk entirely when the cache is populated. Second+ invocations of `Ctrl+Shift+J` no longer re-walk hundreds of files. Cache is invalidated via `vscode.workspace.onDidCreateFiles` / `onDidDeleteFiles` / `onDidRenameFiles`, wired in `Startup`.
- **Parallel `fs.stat` in `walkDir`** — files within a directory are now stat'd via `Promise.all`, and subdirectory recursion is also fanned out. Removes the sequential per-file RPC round-trips that dominated latency on Remote SSH / Codespaces (the extension declares `extensionKind: workspace`).
- **Sorted insertion in `addItemToPickList`** — replaces the O(n² log n) full re-sort of `input.items` on every directory-level callback with binary-search insertion. Eliminates jank as entries populate the QuickPick.
- **Drop `moment` from the activation hot path in `logger.ts`** — `appendCurrentTime` now uses native `Date` + `padStart`, removing one of the call sites that pulled moment into every cold activation via the namespace barrel. (Full `moment` removal stays scheduled for PLAN.md Phase 3.)

## Files

- `src/provider/features/scan-entries.ts` — `clearCache()`, cache short-circuit, `registerInvalidationListeners()`, parallel stat in `walkDir`.
- `src/ext/startup.ts` — `registerCacheInvalidation()` step in the activation chain.
- `src/ext/dialogues.ts` — `getScanner()` accessor; binary-search insertion replacing full re-sort.
- `src/util/logger.ts` — native timestamp formatting.
- `src/test/suite/scan-entries-cache.test.ts` — new regression tests.

## Test plan

- [x] `npm run check` — lint + compile + 102/102 tests passing locally.
- [x] New tests (`Issue #187 — ScanEntries cache short-circuit and invalidation`) cover: first scan walks; second scan with populated cache does NOT walk; `clearCache()` restores dirty state.
- [ ] Manual smoke in Extension Development Host — verify input box opens fast on cold and warm invocations; create/delete files in the base directory and confirm next invocation sees them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)