### PR TITLE
refactor(arch): introduce JournalController interface, break barrel cycle

### DIFF
--- a/docs/plans/2026-05-17-207-interface-journal-controller.md
+++ b/docs/plans/2026-05-17-207-interface-journal-controller.md
@@ -1,0 +1,274 @@
+---
+issue: "#207"
+date: 2026-05-17
+slug: 207-interface-journal-controller
+spec: docs/specs/2026-05-17-207-interface-journal-controller.md
+---
+
+# Plan: Break circular coupling via `JournalController` interface extraction (#207)
+
+## Approach
+
+Introduce `JournalController` (and seven sub-interfaces) in `src/model/interfaces.ts` so action/UI modules can type their `ctrl` parameter without importing the concrete `Ctrl` class via the root barrel. Three configuration types (`EntryGranularity`, `NavigationMode`, `ScopeDefinitionLite`) are moved to `src/model/config.ts` first because `interfaces.ts` must not import from `ext/` — doing so recreates the cycle from the opposite direction.
+
+Main trade-off: this adds seven new interfaces to maintain alongside their concrete implementations. The upside is that TypeScript validates interface coverage at compile time (`Ctrl implements JournalController`), so drift is caught immediately.
+
+## Steps
+
+### Step 1 — Migrate three types from `src/ext/conf.ts` to `src/model/config.ts`
+
+**Why:** `IConfiguration` in `model/interfaces.ts` needs these types in method signatures. If they stay in `ext/conf.ts`, `interfaces.ts` would need to import from `ext/` → `model/ → ext/` cycle.
+
+Move these three declarations verbatim from `ext/conf.ts` to `src/model/config.ts`:
+
+```typescript
+export type EntryGranularity = "daily" | "weekly";
+export type NavigationMode = 'existing' | 'calendar';
+export interface ScopeDefinitionLite { name?: string; base?: string; }
+```
+
+Add re-export in `ext/conf.ts` so existing callers outside the six updated modules compile without change:
+
+```typescript
+export { EntryGranularity, NavigationMode, ScopeDefinitionLite } from '../model/config';
+```
+
+Add to `src/model/index.ts`:
+
+```typescript
+export { EntryGranularity, NavigationMode, ScopeDefinitionLite } from './config';
+```
+
+### Step 2 — Create `src/model/interfaces.ts`
+
+**Why:** Central home for the abstraction. Imports only from `./config` and `./input` (both already in `model/`) — no cross-layer imports.
+
+Full content:
+
+```typescript
+import { EntryGranularity, HeaderTemplate, InlineTemplate, ScopedTemplate } from './config';
+import { Input, InlineString } from './input';
+
+export interface ILogger {
+    trace(message: string, ...params: unknown[]): void;
+    debug(message: string, ...params: unknown[]): void;
+    error(message: string, ...params: unknown[]): void;
+    printError(error: Error): void;
+}
+
+export interface IConfiguration {
+    getLocale(): string;
+    getScopes(): string[];
+    getBasePath(scopeId?: string): string;
+    getEntryGranularity(scopeId?: string): EntryGranularity;
+    getEntryPathPattern(scopeId?: string): string;
+    getNotesPathPattern(scopeId?: string): string;
+    getInputDetailsTimeFormat(): string[];
+    getInputTimeThreshold(): number;
+    isOpenInNewEditorGroup(): boolean;
+    isDevelopmentModeEnabled(): boolean;
+    getResolvedEntryPath(date: Date, scopeId?: string): Promise<ScopedTemplate>;
+    getEntryFilePattern(date: Date, scopeId?: string): Promise<ScopedTemplate>;
+    getResolvedNotesPath(date: Date, scopeId?: string): Promise<ScopedTemplate>;
+    getNotesFilePattern(date: Date, input: string, scopeId?: string): Promise<ScopedTemplate>;
+    getResolvedWeeklyNotesPath(week: number, year: number, scopeId?: string): Promise<ScopedTemplate>;
+    getWeeklyNotesFilePattern(week: number, year: number, input: string, scopeId?: string): Promise<ScopedTemplate>;
+    getWeekPathPattern(week: number, scopeId?: string): Promise<ScopedTemplate>;
+    getWeekFilePattern(week: number, scopeId?: string): Promise<ScopedTemplate>;
+    getEntryTemplate(date: Date, scopeId?: string): Promise<HeaderTemplate>;
+    getWeeklyTemplate(week: number, scopeId?: string): Promise<ScopedTemplate>;
+    getNotesTemplate(scopeId?: string): Promise<HeaderTemplate>;
+    getMemoInlineTemplate(scopeId?: string): Promise<InlineTemplate>;
+    getTaskInlineTemplate(scopeId?: string): Promise<InlineTemplate>;
+}
+
+export interface IParser {
+    parseInput(inputString: string): Promise<Input>;
+    resolveNotePathForInput(input: Input, scopeId?: string): Promise<string>;
+}
+
+export interface IWriter {
+    createEntryForPath(path: ScopedTemplate, date: Date): Promise<ScopedTemplate>;
+    createWeeklyForPath(path: ScopedTemplate, week: number): Promise<ScopedTemplate>;
+    createSaveLoadTextDocument(path: string, content: string): Promise<import('vscode').TextDocument>;
+}
+
+export interface IReader {
+    loadEntryForInput(input: Input): Promise<import('vscode').TextDocument>;
+    loadEntryForWeek(week: number, scope?: string): Promise<import('vscode').TextDocument>;
+    loadEntryForDate(date: Date, scope?: string): Promise<import('vscode').TextDocument>;
+}
+
+export interface IInject {
+    injectInput(doc: import('vscode').TextDocument, input: Input): Promise<import('vscode').TextDocument>;
+    injectString(doc: import('vscode').TextDocument, content: InlineString, pos: import('vscode').Position): Promise<import('vscode').TextDocument>;
+    buildInlineString(doc: import('vscode').TextDocument, tpl: InlineTemplate, ...values: string[][]): Promise<InlineString>;
+    injectInlineString(content: InlineString, ...other: InlineString[]): Promise<import('vscode').TextDocument>;
+    formatNote(input: Input): Promise<string>;
+}
+
+export interface IDialogues {
+    getUserInputWithValidation(): Promise<Input>;
+    getDateInput(): Promise<Input>;
+    pickItem(type: number): Promise<Input>;
+    showDocument(doc: import('vscode').TextDocument): Promise<void>;
+}
+
+export interface JournalController {
+    config: IConfiguration;
+    logger: ILogger;
+    parser: IParser;
+    writer: IWriter;
+    reader: IReader;
+    inject: IInject;
+    ui: IDialogues;
+}
+```
+
+Note: `vscode.TextDocument`, `vscode.Position` are referenced inline via `import('vscode')` to avoid adding a top-level `import * as vscode` that would re-introduce a dependency issue, OR add `import type * as vscode from 'vscode'` at the top — both work since `vscode` is an external (not part of the barrel cycle).
+
+Add to `src/model/index.ts`:
+
+```typescript
+export {
+    ILogger, IConfiguration, IParser, IWriter, IReader, IInject, IDialogues,
+    JournalController
+} from './interfaces';
+```
+
+### Step 3 — `src/util/controller.ts`: add `implements JournalController`
+
+**Why:** Compiler validates that `Ctrl` satisfies the interface. Any missing or mismatched getter surfaces immediately.
+
+```typescript
+import { JournalController } from '../model';
+// ...
+export class Ctrl implements JournalController {
+```
+
+No other changes to `controller.ts` in this issue (barrel removal is #201).
+
+### Step 4 — `src/util/logger.ts`: remove barrel
+
+**Why:** Logger only uses `ctrl.config.isDevelopmentModeEnabled()` from `Ctrl`, plus three util helpers from the barrel.
+
+Replacements:
+
+| Remove | Add |
+|---|---|
+| `import * as J from '../.'` | `import { JournalController } from '../model'` |
+| | `import { isString, isError, isNotNullOrUndefined } from './util'` |
+| | `import { isNotNullOrUndefined } from './strings'` (if `isString` is there) |
+| `J.Util.Ctrl` in constructor | `JournalController` |
+| `J.Util.isString(msg)` | `isString(msg)` |
+| `J.Util.isError(msg)` | `isError(msg)` |
+| `J.Util.isNotNullOrUndefined(...)` | `isNotNullOrUndefined(...)` |
+
+`isString` is in `./strings`, `isError` and `isNotNullOrUndefined` are in `./util`. Import from each directly.
+
+### Step 5 — `src/actions/writer.ts`: remove barrel
+
+**Why:** Writer only uses `J.Util.Ctrl` in the constructor — simplest change in the set.
+
+| Remove | Add |
+|---|---|
+| `import * as J from '../.'` | `import { JournalController } from '../model'` |
+| `J.Util.Ctrl` in constructor | `JournalController` |
+
+### Step 6 — `src/actions/inject.ts`: remove barrel
+
+**Why:** Inject uses model types (`Input`, `InlineTemplate`, `InlineString`, `HeaderTemplate`) and `Ctrl`; all replaceable with direct model imports.
+
+| Remove | Add |
+|---|---|
+| `import * as J from '../.'` | `import { JournalController, Input, InlineTemplate, InlineString, HeaderTemplate } from '../model'` |
+| `J.Model.Input`, `J.Model.InlineTemplate`, etc. | bare names |
+| `J.Util.Ctrl` in constructor | `JournalController` |
+
+### Step 7 — `src/actions/reader.ts`: remove barrel
+
+**Why:** Reader uses `Input`, `resolvePath`, `fileExists` plus `Ctrl`.
+
+| Remove | Add |
+|---|---|
+| `import * as J from '..'` | `import { JournalController, Input } from '../model'` |
+| | `import { resolvePath, fileExists } from '../util'` |
+| `J.Model.Input` | `Input` |
+| `J.Util.resolvePath(...)` | `resolvePath(...)` |
+| `J.Util.fileExists(...)` | `fileExists(...)` |
+| `J.Util.Ctrl` in constructor | `JournalController` |
+
+### Step 8 — `src/actions/parser.ts`: remove barrel
+
+**Why:** Parser uses the most util helpers; all are re-exported from `'../util'` sub-barrel which has no cycle.
+
+| Remove | Add |
+|---|---|
+| `import * as J from '../.'` | `import { JournalController, Input } from '../model'` |
+| | `import { isNotNullOrUndefined, normalizeFilename, getCurrentISOWeek, getISOWeekYear } from '../util'` |
+| `J.Model.Input` | `Input` |
+| `J.Util.*` helpers | bare names |
+| `J.Util.Ctrl` in constructor | `JournalController` |
+
+### Step 9 — `src/ext/dialogues.ts`: remove barrel
+
+**Why:** Dialogues uses `Input`, `JournalPageType`, `isNotNullOrUndefined`, and `DecoratedQuickPickItem`. The latter must be imported directly from `'../provider/features/scan-entries'` — not via the provider barrel — to avoid pulling in the provider index which re-triggers the cycle via `scan-entries → ext/` barrel.
+
+| Remove | Add |
+|---|---|
+| `import * as J from '..'` | `import { JournalController, Input, JournalPageType } from '../model'` |
+| | `import { isNotNullOrUndefined } from '../util'` |
+| | `import { DecoratedQuickPickItem } from '../provider/features/scan-entries'` |
+| `J.Model.Input`, `J.Model.JournalPageType` | bare names |
+| `J.Util.isNotNullOrUndefined(...)` | `isNotNullOrUndefined(...)` |
+| `J.Provider.DecoratedQuickPickItem` | `DecoratedQuickPickItem` |
+| `J.Util.Ctrl` in constructor | `JournalController` |
+
+### Step 10 — Verify
+
+```bash
+npm run compile   # must produce zero errors
+npm run lint      # must produce zero new warnings
+npm test          # must pass with no regressions
+grep -rn "import \* as J" src/util/logger.ts src/actions/ src/ext/dialogues.ts  # must produce no output
+```
+
+## Test scenarios
+
+**T1 — Compile-time interface coverage (unit: TypeScript)**
+`npm run compile` passes. If any `ctrl.*` call in the six files is not covered by `JournalController`/sub-interfaces, tsc reports a type error before any test runs.
+
+**T2 — `Ctrl` satisfies `JournalController` (unit: TypeScript)**
+`Ctrl implements JournalController` in `controller.ts` — tsc validates all getters return the right sub-interface types. Any gap (e.g. missing `ui` getter or wrong return type) is a compile error.
+
+**T3 — No regressions in full test suite (integration)**
+`npm test` passes green. Existing tests exercise the happy path for all six modules through the real Extension Host — confirms structural compatibility at runtime.
+
+**T4 — Barrel-free audit (static)**
+`grep -rn "import \* as J" src/util/logger.ts src/actions/ src/ext/dialogues.ts` returns no output. Enforces the acceptance criterion without running tests.
+
+**T5 — `ext/conf.ts` still compiles after type migration (unit: TypeScript)**
+Callers of `EntryGranularity`, `NavigationMode`, `ScopeDefinitionLite` outside the six files (e.g. `src/provider/`) still compile because `ext/conf.ts` re-exports them from `../model/config`.
+
+## Dependencies
+
+- No other PRs or branches must land first.
+- #201 is a parallel track (fixes `controller.ts` barrel). Implementations are independent; they can merge in either order.
+
+## Risk
+
+| Risk | Coverage |
+|---|---|
+| `IConfiguration` missing a method → `Ctrl implements JournalController` breaks at compile | T1, T2 |
+| `IWriter`/`IReader` return types don't match concrete class → tsc error | T2 |
+| `scan-entries.ts` import in `dialogues.ts` reintroduces `ext/` barrel cycle | T3 (runtime), T4 (static): only direct file import used, not provider index |
+| `conf.ts` callers of migrated types outside six files break | T5 |
+| Runtime behavior change | T3 — no behavior change; pure type-level refactor |
+
+## Rollback
+
+`git revert <commit>` — pure refactor, no data migrations, no API surface changes. Re-introduces barrel imports but does not break functionality.
+
+## Reference spec
+
+[docs/specs/2026-05-17-207-interface-journal-controller.md](../specs/2026-05-17-207-interface-journal-controller.md)

--- a/docs/specs/2026-05-17-207-interface-journal-controller.md
+++ b/docs/specs/2026-05-17-207-interface-journal-controller.md
@@ -1,0 +1,113 @@
+---
+issue: "#207"
+date: 2026-05-17
+slug: 207-interface-journal-controller
+plan: docs/plans/2026-05-17-207-interface-journal-controller.md
+---
+
+# Spec: Break circular coupling via `JournalController` interface extraction (#207)
+
+## Goal
+
+Introduce a `JournalController` interface in `src/model/` so that action and UI modules depend on an abstraction rather than the concrete `Ctrl` class — eliminating the barrel-import cycle in those modules.
+
+## Why now
+
+Every action class (`Parser`, `Writer`, `Reader`, `Inject`), the `Dialogues` class, and `Logger` type-hint `Ctrl` via `import * as J from '../.'`. Because `src/index.ts` re-exports `src/util/` (which contains `Ctrl`), and `src/util/controller.ts` itself imports from the same barrel, the result is a pervasive transitive cycle:
+
+```
+index.ts → util → actions → index.ts
+index.ts → ext  → index.ts
+```
+
+Node.js resolves cycles by returning partially-initialized modules, creating initialization-order fragility. The coupling also prevents unit-testing any action class in isolation without loading the entire barrel. Issue #201 addresses the same cycle from the `controller.ts` side; this issue addresses the action/UI side and provides the abstraction that makes the full cycle breakable.
+
+## In scope
+
+- **New file:** `src/model/interfaces.ts` defining:
+  - `ILogger` — `trace`, `debug`, `error`, `printError` methods
+  - `IConfiguration` — all public methods called by action/UI/logger modules, typed with model-only return types
+  - `IParser` — `parseInput`, `resolveNotePathForInput`
+  - `IWriter` — `createSaveLoadTextDocument`, `createEntryForPath`, `createWeeklyForPath`
+  - `IReader` — `loadEntryForWeek`, `loadEntryForDate`
+  - `IInject` — `injectInput`, `injectString`, `buildInlineString`, `injectInlineString`, `formatNote`
+  - `IDialogues` — `getDateInput`, `getQuickPickInput`, `getUserInput`, `showDocument`
+  - `JournalController` — composes the above sub-interfaces via named properties (`config`, `logger`, `parser`, `writer`, `reader`, `inject`, `ui`)
+- **Type migration:** `EntryGranularity`, `NavigationMode`, `ScopeDefinitionLite` moved from `src/ext/conf.ts` to `src/model/` (re-exported from `src/ext/` for backward compat). Required because `model/interfaces.ts` must not import from `ext/` to avoid creating a new `model/ → ext/ → model/` cycle.
+- **Updated:** `src/model/index.ts` — export new interfaces and migrated types
+- **Updated:** `src/util/controller.ts` — add `implements JournalController`
+- **Updated (barrel removal):** `src/actions/parser.ts`, `writer.ts`, `reader.ts`, `inject.ts`, `src/ext/dialogues.ts`, `src/util/logger.ts` — replace `constructor(public ctrl: J.Util.Ctrl)` with `constructor(public ctrl: JournalController)`, import `JournalController` from `../model`, remove `import * as J from '../.'` entirely
+
+## Out of scope
+
+- `src/provider/commands/*` and other provider files — they also use barrel imports and `Ctrl`; addressed as separate Phase 2.3 work
+- `src/util/controller.ts` barrel removal (fixing its own `import * as J`) — that is #201's work
+- No behavior changes; pure refactor of type dependencies
+
+## Acceptance criteria
+
+1. `src/model/interfaces.ts` exists and exports `JournalController`, `ILogger`, `IConfiguration`, `IParser`, `IWriter`, `IReader`, `IInject`, `IDialogues`
+2. `Ctrl` in `controller.ts` has `implements JournalController` and TypeScript accepts it with no errors
+3. None of the 6 updated modules (`parser.ts`, `writer.ts`, `reader.ts`, `inject.ts`, `dialogues.ts`, `logger.ts`) contain `import * as J from`
+4. `npm run compile` passes with zero errors
+5. `npm run lint` passes with zero new warnings
+6. `npm test` passes with no regressions
+7. No new barrel import (`import * as X from '...'`) introduced in updated files
+
+## Entities / contracts
+
+### `JournalController` (in `src/model/interfaces.ts`)
+
+```typescript
+export interface JournalController {
+    config: IConfiguration;
+    logger: ILogger;
+    parser: IParser;
+    writer: IWriter;
+    reader: IReader;
+    inject: IInject;
+    ui: IDialogues;
+}
+```
+
+### Key constraint: `model/interfaces.ts` imports only from `model/`
+
+All method signatures on sub-interfaces must use types already in `src/model/` (e.g. `Input`, `ScopedTemplate`, `HeaderTemplate`, `InlineTemplate`, `EntryGranularity` after migration). No imports from `src/ext/` or `src/actions/` — that would recreate a cycle from the other direction.
+
+### Types migrated from `src/ext/conf.ts` to `src/model/`
+
+| Type | Used by `IConfiguration` method |
+|---|---|
+| `EntryGranularity = "daily" \| "weekly"` | `getEntryGranularity()` |
+| `NavigationMode = 'existing' \| 'calendar'` | `getNavigationMode()` |
+| `ScopeDefinitionLite { name?: string; base?: string; }` | `getScopeDefinitions()` |
+
+`src/ext/conf.ts` re-exports these from `../model` after migration so existing imports in the codebase outside the updated files continue to compile without change.
+
+### Constructor change in updated modules
+
+```typescript
+// Before
+constructor(public ctrl: J.Util.Ctrl) { ... }
+
+// After
+import { JournalController } from '../model';
+constructor(public ctrl: JournalController) { ... }
+```
+
+## Constraints
+
+- TypeScript `strict` mode — interface must cover every property/method access on `ctrl` in each updated file; missing members cause compile errors
+- `logger.ts` only needs `IConfiguration` sub-interface (specifically `isDevelopmentModeEnabled(): boolean`) — but the simplest fix is accepting `JournalController` in its constructor; no need for a narrower interface just for Logger
+- Do not add `implements IParser` etc. to concrete classes — TypeScript structural typing satisfies the interface check without the keyword; explicit `implements` only on `Ctrl` → `JournalController`
+- ESLint: import names must be `camelCase` or `PascalCase` — all interface/type names satisfy this
+
+## Open questions
+
+None.
+
+## Related issues
+
+- Related: #201 — fixes barrel import in `controller.ts` (complementary, independent track; together they complete Phase 2.3 for the core service layer)
+- See `docs/PLAN.md` Phase 2.3 for broader named-imports roadmap
+- See `docs/analysis/issue_dependency_disorder.md` for the original analysis

--- a/src/actions/inject.ts
+++ b/src/actions/inject.ts
@@ -20,14 +20,15 @@
 
 
 import * as vscode from 'vscode';
-import * as J from '../.';
+import { JournalController, Input, InlineTemplate, InlineString, HeaderTemplate } from '../model';
+import { isNullOrUndefined } from '../util';
 
 
 
 
 export class Inject {
 
-    constructor(public ctrl: J.Util.Ctrl) {
+    constructor(public ctrl: JournalController) {
 
     }
 
@@ -37,11 +38,11 @@ export class Inject {
      * document.
      *
      * @param {vscode.TextDocument} doc
-     * @param {J.Model.Input} input
+     * @param {Input} input
      * @returns {Q.Promise<vscode.TextDocument>}
      * @memberof Inject
      */
-    public async injectInput(doc: vscode.TextDocument, input: J.Model.Input): Promise<vscode.TextDocument> {
+    public async injectInput(doc: vscode.TextDocument, input: Input): Promise<vscode.TextDocument> {
         this.ctrl.logger.trace("Entering injectInput() in inject.ts with Input:", JSON.stringify(input));
 
         if (!input.hasMemo() || !input.hasFlags()) {
@@ -83,7 +84,7 @@ export class Inject {
      * 
      * Updates: Fix for  #55, always make sure there is a linebreak between the header and the injected text to stay markdown compliant
      */
-    public async buildInlineString(doc: vscode.TextDocument, tpl: J.Model.InlineTemplate, ...values: string[][]): Promise<J.Model.InlineString> {
+    public async buildInlineString(doc: vscode.TextDocument, tpl: InlineTemplate, ...values: string[][]): Promise<InlineString> {
         this.ctrl.logger.trace("Entering buildInlineString() in inject.ts with InlineTemplate: ", JSON.stringify(tpl), " and values ", JSON.stringify(values));
 
         let content: string = tpl.value!;
@@ -99,7 +100,7 @@ export class Inject {
         };
     }
 
-    public adjustLineBreak(tpl: J.Model.InlineTemplate, content: string): string {
+    public adjustLineBreak(tpl: InlineTemplate, content: string): string {
         // if (tpl-after) is empty, we will inject directly after header
         if (tpl.after.length !== 0) {
             if (tpl.after.startsWith("#")) {
@@ -113,7 +114,7 @@ export class Inject {
         return content;
     }
 
-    public computePositionForInput(doc: vscode.TextDocument, tpl: J.Model.InlineTemplate): vscode.Position {
+    public computePositionForInput(doc: vscode.TextDocument, tpl: InlineTemplate): vscode.Position {
         // if (tpl-after) is empty, we will inject directly after header
         let position: vscode.Position = new vscode.Position(1, 0);
         if (tpl.after.length !== 0) {
@@ -147,10 +148,10 @@ export class Inject {
      * @param other additional InlineStrings
      * 
      */
-    public async injectInlineString(content: J.Model.InlineString, ...other: J.Model.InlineString[]): Promise<vscode.TextDocument> {
+    public async injectInlineString(content: InlineString, ...other: InlineString[]): Promise<vscode.TextDocument> {
         this.ctrl.logger.trace("Entering injectInlineString() in inject.ts with string: ", content.value.trim());
 
-        if (J.Util.isNullOrUndefined(content)) {
+        if (isNullOrUndefined(content)) {
             this.ctrl.logger.error("Content is null");
             throw new Error("Invalid call, no reference to document due to null content.");
         }
@@ -159,13 +160,13 @@ export class Inject {
         const modifiedContent = this.formatContent(content);
         edit.insert(modifiedContent.document.uri, modifiedContent.position, modifiedContent.value);
 
-        if (!J.Util.isNullOrUndefined(other) && other.length > 0) {
+        if (!isNullOrUndefined(other) && other.length > 0) {
             other.forEach(additionalContent => {
                 edit.insert(additionalContent.document.uri, additionalContent.position, additionalContent.value);
             });
         }
 
-        if (J.Util.isNullOrUndefined(edit) || edit.size === 0) {
+        if (isNullOrUndefined(edit) || edit.size === 0) {
             this.ctrl.logger.trace("No changes have been made to the document: ", content.document.fileName);
             return content.document;
         }
@@ -178,8 +179,8 @@ export class Inject {
         return content.document;
     }
 
-    private formatContent(content: J.Model.InlineString) {
-        if (J.Util.isNullOrUndefined(content.position)) {
+    private formatContent(content: InlineString) {
+        if (isNullOrUndefined(content.position)) {
             content.position = new vscode.Position(1, 0);
         }
 
@@ -229,13 +230,13 @@ export class Inject {
     /**
      * Builds the content of newly created notes file using the (scoped) configuration and the user input. 
      *1
-     * @param {J.Model.Input} input what the user has entered
+     * @param {Input} input what the user has entered
      * @returns {Q.Promise<string>} the built content
      * @memberof Inject
      */
-    public async formatNote(input: J.Model.Input): Promise<string> {
+    public async formatNote(input: Input): Promise<string> {
         this.ctrl.logger.trace("Entering formatNote() in inject.ts with input: ", JSON.stringify(input));
-        const headerTemplate: J.Model.HeaderTemplate = await this.ctrl.config.getNotesTemplate(input.scope);
+        const headerTemplate: HeaderTemplate = await this.ctrl.config.getNotesTemplate(input.scope);
         headerTemplate.value = headerTemplate.value!.replace('${input}', input.text);
         headerTemplate.value = headerTemplate.value!.replace('${tags}', input.tags.join(" ") + '\n');
 

--- a/src/actions/parser.ts
+++ b/src/actions/parser.ts
@@ -17,17 +17,18 @@
 // 
 'use strict';
 
-import * as J from '../.';
 import * as Path from 'path';
-
+import { JournalController, Input } from '../model';
+import { isNullOrUndefined, isNotNullOrUndefined, normalizeFilename, getCurrentISOWeek, getISOWeekYear } from '../util';
 import { SCOPE_DEFAULT } from '../ext';
+import { MatchInput } from '../provider/features/match-input';
 
 /**
  * Helper Methods to interpret the input strings
  */
 export class Parser {
 
-    constructor(public ctrl: J.Util.Ctrl) {
+    constructor(public ctrl: JournalController) {
     }
 
     /**
@@ -39,7 +40,7 @@ export class Parser {
      * @memberof JournalCommands
      * 
      */
-    public async resolveNotePathForInput(input: J.Model.Input, scopeId?: string): Promise<string> {
+    public async resolveNotePathForInput(input: Input, scopeId?: string): Promise<string> {
 
 
 
@@ -49,32 +50,32 @@ export class Parser {
         input.scope = SCOPE_DEFAULT;
 
         input.text.match(/#\w+\s/g)?.forEach(tag => {
-            if (J.Util.isNullOrUndefined(tag) || tag!.length === 0) { return; }
+            if (isNullOrUndefined(tag) || tag!.length === 0) { return; }
             this.ctrl.logger.trace("Tags in input string: " + tag);
             input.tags.push(tag.trim().substring(0, tag.length - 1));
             input.text = input.text.replace(tag, " ");
             this.ctrl.logger.trace("Scopes defined in configuration: " + this.ctrl.config.getScopes());
             const scope: string | undefined = this.ctrl.config.getScopes().filter((name: string) => name === tag.trim().substring(1, tag.length)).pop();
-            if (J.Util.isNotNullOrUndefined(scope) && scope!.length > 0) {
+            if (isNotNullOrUndefined(scope) && scope!.length > 0) {
                 input.scope = scope!;
             }
             this.ctrl.logger.trace("Identified scope in input: " + input.scope);
         });
 
-        const inputForFileName = J.Util.normalizeFilename(input.text);
+        const inputForFileName = normalizeFilename(input.text);
         const granularity = this.ctrl.config.getEntryGranularity(input.scope);
         const filePromise = granularity === "weekly"
             ? this.ctrl.config.getWeeklyNotesFilePattern(
-                J.Util.getCurrentISOWeek(date),
-                J.Util.getISOWeekYear(date),
+                getCurrentISOWeek(date),
+                getISOWeekYear(date),
                 inputForFileName,
                 input.scope,
             )
             : this.ctrl.config.getNotesFilePattern(date, inputForFileName, input.scope);
         const pathPromise = granularity === "weekly"
             ? this.ctrl.config.getResolvedWeeklyNotesPath(
-                J.Util.getCurrentISOWeek(date),
-                J.Util.getISOWeekYear(date),
+                getCurrentISOWeek(date),
+                getISOWeekYear(date),
                 input.scope,
             )
             : this.ctrl.config.getResolvedNotesPath(date, input.scope);
@@ -100,8 +101,8 @@ export class Parser {
      * @returns {Promise<J.Model.Input>} the resolved input object
      * @memberof Parser
      */
-    public async parseInput(inputString: string): Promise<J.Model.Input> {
-        let inputMatcher = new J.Provider.MatchInput(
+    public async parseInput(inputString: string): Promise<Input> {
+        let inputMatcher = new MatchInput(
             this.ctrl.logger,
             this.ctrl.config.getLocale(),
             this.ctrl.config.getEntryGranularity(),

--- a/src/actions/reader.ts
+++ b/src/actions/reader.ts
@@ -19,12 +19,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { JournalController, Input } from '../model';
+import { isNullOrUndefined, resolvePath, fileExists } from '../util';
 
 export class Reader {
     public onNotesInjected?: (doc: vscode.TextDocument, date: Date) => void;
 
-    constructor(public ctrl: J.Util.Ctrl) {
+    constructor(public ctrl: JournalController) {
     }
 
 
@@ -36,7 +37,7 @@ export class Reader {
   * @returns {Q.Promise<vscode.TextDocument>} the document
   * @memberof Reader
   */
-    public async loadEntryForInput(input: J.Model.Input): Promise<vscode.TextDocument> {
+    public async loadEntryForInput(input: Input): Promise<vscode.TextDocument> {
 
         if (input.hasOffset()) {
             return this.loadEntryForDay(input.generateDate(), input.scope);
@@ -60,7 +61,7 @@ export class Reader {
             this.ctrl.config.getWeekPathPattern(week, scope),
             this.ctrl.config.getWeekFilePattern(week, scope),
         ]);
-        const path = J.Util.resolvePath(pathname.value!, filename.value!);
+        const path = resolvePath(pathname.value!, filename.value!);
 
         const doc = await this.openOrCreate(
             path,
@@ -79,7 +80,7 @@ export class Reader {
      * @memberof Reader
      */
     public async loadEntryForDay(date: Date, scope?: string): Promise<vscode.TextDocument> {
-        if (J.Util.isNullOrUndefined(date) || date!.toString().includes("Invalid")) {
+        if (isNullOrUndefined(date) || date!.toString().includes("Invalid")) {
             throw new Error("Invalid date");
         }
         this.ctrl.logger.trace("Entering loadEntryforDate() in actions/reader.ts for date " + date.toISOString());
@@ -88,7 +89,7 @@ export class Reader {
             this.ctrl.config.getResolvedEntryPath(date, scope),
             this.ctrl.config.getEntryFilePattern(date, scope),
         ]);
-        const path = J.Util.resolvePath(pathname.value!, filename.value!);
+        const path = resolvePath(pathname.value!, filename.value!);
 
         const doc = await this.openOrCreate(
             path,
@@ -105,7 +106,7 @@ export class Reader {
         path: string,
         create: () => Promise<vscode.TextDocument>,
     ): Promise<vscode.TextDocument> {
-        const exists = await J.Util.fileExists(vscode.Uri.file(path));
+        const exists = await fileExists(vscode.Uri.file(path));
         if (exists) {
             return this.ctrl.ui.openDocument(path);
         }

--- a/src/actions/writer.ts
+++ b/src/actions/writer.ts
@@ -19,7 +19,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '../.';
+import { JournalController } from '../model';
 
 /** 
  * Anything which modifies the text documents goes here. 
@@ -28,7 +28,7 @@ import * as J from '../.';
 export class Writer {
 
 
-    constructor(public ctrl: J.Util.Ctrl) {
+    constructor(public ctrl: JournalController) {
     }
 
     public async saveDocument(doc: vscode.TextDocument): Promise<vscode.TextDocument> {

--- a/src/ext/conf.ts
+++ b/src/ext/conf.ts
@@ -46,9 +46,8 @@ type PatternDefinition = {
     weeklyNotes?: { path: string; file: string };
 };
 
-export type EntryGranularity = "daily" | "weekly";
-export type NavigationMode = 'existing' | 'calendar';
-export interface ScopeDefinitionLite { name?: string; base?: string; }
+export { EntryGranularity, NavigationMode, ScopeDefinitionLite } from '../model/config';
+import { EntryGranularity, NavigationMode, ScopeDefinitionLite } from '../model/config';
 
 const defaultPatternDefinition: PatternDefinition =
 {

--- a/src/ext/dialogues.ts
+++ b/src/ext/dialogues.ts
@@ -19,13 +19,12 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
 import * as Path from 'path';
-import { isNotNullOrUndefined, } from '../util';
+import { isNotNullOrUndefined, isString, isError, stringIsNotEmpty, denormalizeFilename } from '../util';
 import { SCOPE_DEFAULT } from './conf';
 import moment = require('moment');
-import { JournalPageType } from '../model';
-import { sortPickEntries } from '../provider';
+import { JournalController, JournalPageType, Input, ScopeDirectory, NoteInput, SelectedInput, FileEntry } from '../model';
+import { sortPickEntries, ScanEntries, TimedQuickPick, DecoratedQuickPickItem } from '../provider/features/scan-entries';
 
 
 
@@ -36,13 +35,13 @@ import { sortPickEntries } from '../provider';
  */
 export class Dialogues {
 
-    private scanner: J.Provider.ScanEntries;
+    private scanner: ScanEntries;
 
-    constructor(public ctrl: J.Util.Ctrl) {
-        this.scanner = new J.Provider.ScanEntries(this.ctrl);
+    constructor(public ctrl: JournalController) {
+        this.scanner = new ScanEntries(this.ctrl);
     }
 
-    public getScanner(): J.Provider.ScanEntries {
+    public getScanner(): ScanEntries {
         return this.scanner;
     }
 
@@ -50,26 +49,26 @@ export class Dialogues {
     /**
      * 
      */
-    public async getUserInputWithValidation(): Promise<J.Model.Input> {
+    public async getUserInputWithValidation(): Promise<Input> {
         return new Promise((resolve, reject) => {
             const disposables: vscode.Disposable[] = [];
 
             try {
                 // see https://github.com/Microsoft/vscode-extension-samples/blob/master/quickinput-sample/src/quickOpen.ts
-                const input: J.Provider.TimedQuickPick = vscode.window.createQuickPick<J.Provider.DecoratedQuickPickItem>();
+                const input: TimedQuickPick = vscode.window.createQuickPick<DecoratedQuickPickItem>();
                 input.start = new Date().getTime();
 
                 // FIXME: localize
                 input.show();
 
 
-                let today: J.Provider.DecoratedQuickPickItem = { label: vscode.l10n.t("Today"), description: vscode.l10n.t("Jump to today's entry."), pickItem: J.Model.JournalPageType.entry, parsedInput: new J.Model.Input(0), alwaysShow: true, path: "" };
-                let tomorrow: J.Provider.DecoratedQuickPickItem = { label: vscode.l10n.t("Tomorrow"), description: vscode.l10n.t("Jump to tomorrow's entry."), pickItem: J.Model.JournalPageType.entry, parsedInput: new J.Model.Input(1), alwaysShow: true, path: "" };
-                let pickEntry: J.Provider.DecoratedQuickPickItem = { label: vscode.l10n.t("Select entry"), description: vscode.l10n.t("Select from the last journal entries."), pickItem: J.Model.JournalPageType.entry, alwaysShow: true, path: "" };
-                let pickNote: J.Provider.DecoratedQuickPickItem = { label: vscode.l10n.t("Select/Create a note"), description: vscode.l10n.t("Create a new note or select from recently created or updated notes."), pickItem: J.Model.JournalPageType.note, alwaysShow: true, path: "" };
+                let today: DecoratedQuickPickItem = { label: vscode.l10n.t("Today"), description: vscode.l10n.t("Jump to today's entry."), pickItem: JournalPageType.entry, parsedInput: new Input(0), alwaysShow: true, path: "" };
+                let tomorrow: DecoratedQuickPickItem = { label: vscode.l10n.t("Tomorrow"), description: vscode.l10n.t("Jump to tomorrow's entry."), pickItem: JournalPageType.entry, parsedInput: new Input(1), alwaysShow: true, path: "" };
+                let pickEntry: DecoratedQuickPickItem = { label: vscode.l10n.t("Select entry"), description: vscode.l10n.t("Select from the last journal entries."), pickItem: JournalPageType.entry, alwaysShow: true, path: "" };
+                let pickNote: DecoratedQuickPickItem = { label: vscode.l10n.t("Select/Create a note"), description: vscode.l10n.t("Create a new note or select from recently created or updated notes."), pickItem: JournalPageType.note, alwaysShow: true, path: "" };
                 input.items = [today, tomorrow, pickEntry, pickNote];
 
-                let selected: J.Provider.DecoratedQuickPickItem | undefined;
+                let selected: DecoratedQuickPickItem | undefined;
 
                 input.onDidChangeValue(val => {
 
@@ -81,9 +80,9 @@ export class Dialogues {
                         }
                         return;
                     } else {
-                        this.ctrl.parser.parseInput(val).then((parsed: J.Model.Input) => {
+                        this.ctrl.parser.parseInput(val).then((parsed: Input) => {
                             // this is the placeholder, which gets continuously updated when the user types in anything
-                            let item: J.Provider.DecoratedQuickPickItem = {
+                            let item: DecoratedQuickPickItem = {
                                 label: val,
                                 path: "",
                                 alwaysShow: true,
@@ -117,19 +116,19 @@ export class Dialogues {
                 input.onDidAccept(val => {
                     if (!selected) { return; }
 
-                    if (J.Util.isNotNullOrUndefined(selected.parsedInput)) {
-                        resolve(selected.parsedInput as J.Model.Input);
+                    if (isNotNullOrUndefined(selected.parsedInput)) {
+                        resolve(selected.parsedInput as Input);
 
-                    } else if (J.Util.isNotNullOrUndefined(selected.pickItem) && selected.pickItem === J.Model.JournalPageType.entry) {
-                        this.pickItem(J.Model.JournalPageType.entry).then(selected => {
+                    } else if (isNotNullOrUndefined(selected.pickItem) && selected.pickItem === JournalPageType.entry) {
+                        this.pickItem(JournalPageType.entry).then(selected => {
                             resolve(selected);
                         });
-                    } else if (J.Util.isNotNullOrUndefined(selected.pickItem) && selected.pickItem === J.Model.JournalPageType.note) {
-                        this.pickItem(J.Model.JournalPageType.note).then(selected => {
+                    } else if (isNotNullOrUndefined(selected.pickItem) && selected.pickItem === JournalPageType.note) {
+                        this.pickItem(JournalPageType.note).then(selected => {
                             resolve(selected);
                         });
-                    } else if (J.Util.isNotNullOrUndefined(selected.pickItem) && selected.pickItem === J.Model.JournalPageType.attachement) {
-                        this.pickItem(J.Model.JournalPageType.attachement).then(selected => {
+                    } else if (isNotNullOrUndefined(selected.pickItem) && selected.pickItem === JournalPageType.attachement) {
+                        this.pickItem(JournalPageType.attachement).then(selected => {
                             resolve(selected);
                         });
                     } else {
@@ -148,7 +147,7 @@ export class Dialogues {
     };
 
 
-    private generateDescription(parsed: J.Model.Input): string {
+    private generateDescription(parsed: Input): string {
         moment.locale(this.ctrl.config.getLocale());
 
         let date = new Date();
@@ -157,7 +156,7 @@ export class Dialogues {
     }
 
 
-    private generateDetail(parsed: J.Model.Input): string {
+    private generateDetail(parsed: Input): string {
         moment.locale(this.ctrl.config.getLocale());
 
         let date = new Date();
@@ -183,10 +182,10 @@ export class Dialogues {
     }
 
 
-    private collectScanDirectories(type: J.Model.JournalPageType): Set<J.Model.ScopeDirectory> {
+    private collectScanDirectories(type: JournalPageType): Set<ScopeDirectory> {
 
 
-        let baseDirectories: J.Model.ScopeDirectory[] = [];
+        let baseDirectories: ScopeDirectory[] = [];
         this.ctrl.config.getScopes().forEach(scope => {
             // let dir = this.ctrl.config.getBasePath(scope); 
             let pattern = "";
@@ -211,13 +210,13 @@ export class Dialogues {
             }
             const directory = Path.join(...filteredSegments);
 
-            let scopedBaseDirectory: J.Model.ScopeDirectory = {
+            let scopedBaseDirectory: ScopeDirectory = {
                 path: directory,
                 scope: scope
             };
 
 
-            if (J.Util.stringIsNotEmpty(scopedBaseDirectory.path)) {
+            if (stringIsNotEmpty(scopedBaseDirectory.path)) {
                 if (baseDirectories.findIndex(item => item.path === scopedBaseDirectory.path) === -1) {
                     baseDirectories.push(scopedBaseDirectory);
                 }
@@ -232,7 +231,7 @@ export class Dialogues {
      * 
      * @param type 
      */
-    public async pickItem(type: J.Model.JournalPageType): Promise<J.Model.Input> {
+    public async pickItem(type: JournalPageType): Promise<Input> {
         return new Promise((resolve, reject) => {
 
             const disposables: vscode.Disposable[] = [];
@@ -240,11 +239,11 @@ export class Dialogues {
             try {
 
                 // Fixme, identify scopes while typing and switch base path if needed
-                const input: J.Provider.TimedQuickPick = vscode.window.createQuickPick<J.Provider.DecoratedQuickPickItem>();
+                const input: TimedQuickPick = vscode.window.createQuickPick<DecoratedQuickPickItem>();
                 input.start = new Date().getTime();
                 input.matchOnDescription = true;
 
-                let selected: J.Provider.DecoratedQuickPickItem | undefined;
+                let selected: DecoratedQuickPickItem | undefined;
 
                 input.busy = true;
 
@@ -258,7 +257,7 @@ export class Dialogues {
                 }, disposables);
 
                 // placeholder only for notes
-                if (type === J.Model.JournalPageType.note) {
+                if (type === JournalPageType.note) {
                     input.onDidChangeValue(val => {
                         if (val.length === 0) {
                             if (input.items[0].replace && input.items[0].replace === true) {
@@ -266,7 +265,7 @@ export class Dialogues {
                             }
                             return;
                         } else {
-                            let inputText = new J.Model.NoteInput();
+                            let inputText = new NoteInput();
                             inputText.text = val;
 
 
@@ -287,7 +286,7 @@ export class Dialogues {
                                     description += " and tags " + inputText.tags;
                                 }
 
-                                let item: J.Provider.DecoratedQuickPickItem = {
+                                let item: DecoratedQuickPickItem = {
                                     label: inputText.text,
                                     path: path,
                                     alwaysShow: true,
@@ -314,7 +313,7 @@ export class Dialogues {
                         if (isNotNullOrUndefined(selected!.parsedInput)) {
                             resolve(selected!.parsedInput!);
                         } else {
-                            resolve(new J.Model.SelectedInput(selected!.path));
+                            resolve(new SelectedInput(selected!.path));
                         }
 
                     } else { reject("cancel"); }
@@ -396,11 +395,11 @@ export class Dialogues {
 
     public async showError(error: string | Error): Promise<void> {
 
-        if (J.Util.isString(error)) {
+        if (isString(error)) {
             this.showErrorInternal(error as string);
         }
 
-        if (J.Util.isError(error)) {
+        if (isError(error)) {
             this.showErrorInternal((error as Error).message);
         }
     }
@@ -421,9 +420,9 @@ export class Dialogues {
     * 
     * @param fe 
     */
-function addItemToPickList(entries: J.Model.FileEntry[], input: J.Provider.TimedQuickPick, type: J.Model.JournalPageType) {
+function addItemToPickList(entries: FileEntry[], input: TimedQuickPick, type: JournalPageType) {
 
-    const items: J.Provider.DecoratedQuickPickItem[] = [];
+    const items: DecoratedQuickPickItem[] = [];
 
     entries.forEach(fe => {
         Object.freeze(fe);     // immutable
@@ -437,14 +436,14 @@ function addItemToPickList(entries: J.Model.FileEntry[], input: J.Provider.Timed
         let displayName = fe.name;
 
         // if it's a journal page, we prefix the month for visualizing 
-        if (type === J.Model.JournalPageType.entry) {
+        if (type === JournalPageType.entry) {
             let pathItems = fe.path.split(Path.sep);
             displayName = pathItems[pathItems.length - 2] + Path.sep + pathItems[pathItems.length - 1];
         }
 
         // if it's a note, we denormalize the displayed name
-        if (type === J.Model.JournalPageType.note) {
-            displayName = J.Util.denormalizeFilename(fe.name);
+        if (type === JournalPageType.note) {
+            displayName = denormalizeFilename(fe.name);
         }
 
         /* and we prefix the scope (#122) 
@@ -484,7 +483,7 @@ function addItemToPickList(entries: J.Model.FileEntry[], input: J.Provider.Timed
 
 
 
-        let item: J.Provider.DecoratedQuickPickItem = {
+        let item: DecoratedQuickPickItem = {
             label: displayName,
             path: fe.path,
             fileEntry: fe,

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -27,3 +27,8 @@ export interface HeaderTemplate extends ScopedTemplate {
 export interface InlineTemplate extends ScopedTemplate {
     after: string;
 }
+
+export type EntryGranularity = "daily" | "weekly";
+export type NavigationMode = 'existing' | 'calendar';
+export interface ScopeDefinitionLite { name?: string; base?: string; }
+export type InputDetailsTimeFormat = { sameDay: string; nextDay: string; nextWeek: string; lastDay: string; lastWeek: string; sameElse: string; };

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -17,9 +17,10 @@
 // 
 
 
-export { HeaderTemplate, InlineTemplate, JournalPageType, ScopedTemplate } from './config';
+export { EntryGranularity, HeaderTemplate, InlineTemplate, InputDetailsTimeFormat, JournalPageType, NavigationMode, ScopeDefinitionLite, ScopedTemplate } from './config';
 export { InlineString } from './inline';
 export { Input, NoteInput, SelectedInput } from './input';
 export { ScopeDirectory, TemplateInfo } from './templates';
 export { FileEntry } from './files';
+export { ILogger, IConfiguration, IParser, IWriter, IReader, IInject, IDialogues, JournalController } from './interfaces';
 

--- a/src/model/interfaces.ts
+++ b/src/model/interfaces.ts
@@ -1,0 +1,86 @@
+import type * as vscode from 'vscode';
+import { EntryGranularity, HeaderTemplate, InlineTemplate, InputDetailsTimeFormat, ScopedTemplate } from './config';
+import { InlineString } from './inline';
+import { Input } from './input';
+import { JournalPageType } from './config';
+
+export interface ILogger {
+    trace(message: string, ...params: unknown[]): void;
+    debug(message: string, ...params: unknown[]): void;
+    error(message: string, ...params: unknown[]): void;
+    printError(error: Error): void;
+    showChannel(): void;
+}
+
+export interface IConfiguration {
+    getLocale(): string;
+    getScopes(): string[];
+    getBasePath(scopeId?: string): string;
+    getEntryGranularity(scopeId?: string): EntryGranularity;
+    getEntryPathPattern(scopeId?: string): string;
+    getNotesPathPattern(scopeId?: string): string;
+    getFileExtension(scopeId?: string): string;
+    getInputDetailsTimeFormat(): InputDetailsTimeFormat;
+    getInputTimeThreshold(): number;
+    isOpenInNewEditorGroup(): boolean;
+    isDevelopmentModeEnabled(): boolean;
+    getResolvedEntryPath(date: Date, scopeId?: string): Promise<ScopedTemplate>;
+    getEntryFilePattern(date: Date, scopeId?: string): Promise<ScopedTemplate>;
+    getResolvedNotesPath(date: Date, scopeId?: string): Promise<ScopedTemplate>;
+    getNotesFilePattern(date: Date, input: string, scopeId?: string): Promise<ScopedTemplate>;
+    getResolvedWeeklyNotesPath(week: number, year: number, scopeId?: string): Promise<ScopedTemplate>;
+    getWeeklyNotesFilePattern(week: number, year: number, input: string, scopeId?: string): Promise<ScopedTemplate>;
+    getWeekPathPattern(week: Number, scopeId?: string): Promise<ScopedTemplate>;
+    getWeekFilePattern(week: Number, scopeId?: string): Promise<ScopedTemplate>;
+    getEntryTemplate(date: Date, scopeId?: string): Promise<HeaderTemplate>;
+    getWeeklyTemplate(week: Number, scopeId?: string): Promise<ScopedTemplate>;
+    getNotesTemplate(scopeId?: string): Promise<HeaderTemplate>;
+    getMemoInlineTemplate(scopeId?: string): Promise<InlineTemplate>;
+    getTaskInlineTemplate(scopeId?: string): Promise<InlineTemplate>;
+}
+
+export interface IParser {
+    parseInput(inputString: string): Promise<Input>;
+    resolveNotePathForInput(input: Input, scopeId?: string): Promise<string>;
+}
+
+export interface IWriter {
+    createEntryForPath(path: string, date: Date): Promise<vscode.TextDocument>;
+    createWeeklyForPath(path: string, week: Number): Promise<vscode.TextDocument>;
+    createSaveLoadTextDocument(path: string, content: string): Promise<vscode.TextDocument>;
+}
+
+export interface IReader {
+    loadEntryForInput(input: Input): Promise<vscode.TextDocument>;
+    loadEntryForWeek(week: Number, scope?: string): Promise<vscode.TextDocument>;
+    loadEntryForDay(date: Date, scope?: string): Promise<vscode.TextDocument>;
+}
+
+export interface IInject {
+    injectInput(doc: vscode.TextDocument, input: Input): Promise<vscode.TextDocument>;
+    injectString(doc: vscode.TextDocument, content: string, position: vscode.Position): Promise<vscode.TextDocument>;
+    buildInlineString(doc: vscode.TextDocument, tpl: InlineTemplate, ...values: string[][]): Promise<InlineString>;
+    computePositionForInput(doc: vscode.TextDocument, tpl: InlineTemplate): vscode.Position;
+    injectInlineString(content: InlineString, ...other: InlineString[]): Promise<vscode.TextDocument>;
+    formatNote(input: Input): Promise<string>;
+}
+
+export interface IDialogues {
+    getUserInputWithValidation(): Promise<Input>;
+    pickItem(type: JournalPageType): Promise<Input>;
+    getUserInput(tip: string): Promise<string>;
+    saveDocument(textDocument: vscode.TextDocument): Promise<vscode.TextDocument>;
+    openDocument(path: string | vscode.Uri): Promise<vscode.TextDocument>;
+    showDocument(textDocument: vscode.TextDocument): Promise<vscode.TextEditor>;
+    showError(error: string | Error): Promise<void>;
+}
+
+export interface JournalController {
+    config: IConfiguration;
+    logger: ILogger;
+    parser: IParser;
+    writer: IWriter;
+    reader: IReader;
+    inject: IInject;
+    ui: IDialogues;
+}

--- a/src/provider/features/scan-entries.ts
+++ b/src/provider/features/scan-entries.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import * as Path from 'path';
 import { SCOPE_DEFAULT } from '../../ext';
-import { FileEntry } from '../../model';
+import { FileEntry, JournalController } from '../../model';
 
 export interface DecoratedQuickPickItem extends vscode.QuickPickItem {
     parsedInput?: J.Model.Input;
@@ -25,7 +25,7 @@ export interface TimedQuickPick extends vscode.QuickPick<DecoratedQuickPickItem>
 export class ScanEntries {
 
     private cache: Map<String, J.Model.FileEntry>;
-    constructor(public ctrl: J.Util.Ctrl) {
+    constructor(public ctrl: JournalController) {
         this.cache = new Map();
     }
 

--- a/src/util/controller.ts
+++ b/src/util/controller.ts
@@ -22,8 +22,9 @@
 
 import * as J from '../.';
 import * as vscode from 'vscode';
+import { JournalController } from '../model';
 
-export class Ctrl {
+export class Ctrl implements JournalController {
 
 
     private _config: J.Extension.Configuration;

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -18,7 +18,9 @@
 
 
 import * as vscode from 'vscode';
-import * as J from '../.';
+import { JournalController } from '../model';
+import { isString } from './strings';
+import { isError, isNotNullOrUndefined } from './util';
 
 export interface Logger {
     trace(message: string, ...optionalParams: any[]): void; 
@@ -34,7 +36,7 @@ export class ConsoleLogger implements Logger {
     private devMode = false; 
 
 
-    constructor(public ctrl: J.Util.Ctrl, public channel: vscode.OutputChannel) {
+    constructor(public ctrl: JournalController, public channel: vscode.OutputChannel) {
         this.devMode = ctrl.config.isDevelopmentModeEnabled();
     }
 
@@ -103,17 +105,17 @@ export class ConsoleLogger implements Logger {
             this.channel.append(" ");
         }
         optionalParams.forEach(msg => {
-            if(J.Util.isString(msg)) {
+            if(isString(msg)) {
                 this.channel.append(msg+""); 
             }
-            else if(J.Util.isError(msg)) { 
-                if(J.Util.isNotNullOrUndefined(msg.stack)) {
+            else if(isError(msg)) { 
+                if(isNotNullOrUndefined(msg.stack)) {
                     let method: string | undefined = /at \w+\.(\w+)/.exec(msg.stack!.split('\n')[2])?.pop(); 
                     this.channel.append("("+method+")"); 
                 }
 
                 this.channel.appendLine("See Exception below."); 
-                if(J.Util.isNotNullOrUndefined(msg.stack)) {
+                if(isNotNullOrUndefined(msg.stack)) {
                     this.channel.append(msg.stack); 
                 }
 


### PR DESCRIPTION
## Summary

- Introduces `JournalController` and seven sub-interfaces (`ILogger`, `IConfiguration`, `IParser`, `IWriter`, `IReader`, `IInject`, `IDialogues`) in `src/model/interfaces.ts`
- Removes `import * as J from '../.'` barrel from `logger.ts`, `parser.ts`, `writer.ts`, `reader.ts`, `inject.ts`, `dialogues.ts`
- Migrates `EntryGranularity`, `NavigationMode`, `ScopeDefinitionLite`, `InputDetailsTimeFormat` to `src/model/config.ts`; `ext/conf.ts` re-exports them for backward compat
- `Ctrl` declares `implements JournalController` — TypeScript validates coverage at compile time
- `ScanEntries` constructor updated to `JournalController` (minimal change; barrel stays for its other usages pending Phase 2.3 cleanup)

## Related

- Closes #207
- Related: #201 (barrel removal in `controller.ts` — complementary, independent track)
- Spec: `docs/specs/2026-05-17-207-interface-journal-controller.md`
- Plan: `docs/plans/2026-05-17-207-interface-journal-controller.md`

## Test plan

- [x] `npm run compile` — zero errors
- [x] `npm run lint` — zero warnings
- [x] `npm test` — 126/126 pass, no regressions
- [x] `grep -rn "import \* as J from"` in the 6 updated modules — no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)