### PR TITLE
refactor(di): decompose Ctrl god object via constructor injection (#208)

### DIFF
--- a/src/actions/inject.ts
+++ b/src/actions/inject.ts
@@ -20,7 +20,7 @@
 
 
 import * as vscode from 'vscode';
-import { JournalController, Input, InlineTemplate, InlineString, HeaderTemplate } from '../model';
+import { IConfiguration, ILogger, Input, InlineTemplate, InlineString, HeaderTemplate } from '../model';
 import { isNullOrUndefined } from '../util';
 
 
@@ -28,8 +28,7 @@ import { isNullOrUndefined } from '../util';
 
 export class Inject {
 
-    constructor(public ctrl: JournalController) {
-
+    constructor(private config: IConfiguration, private logger: ILogger) {
     }
 
     /**
@@ -43,7 +42,7 @@ export class Inject {
      * @memberof Inject
      */
     public async injectInput(doc: vscode.TextDocument, input: Input): Promise<vscode.TextDocument> {
-        this.ctrl.logger.trace("Entering injectInput() in inject.ts with Input:", JSON.stringify(input));
+        this.logger.trace("Entering injectInput() in inject.ts with Input:", JSON.stringify(input));
 
         if (!input.hasMemo() || !input.hasFlags()) {
             return doc;
@@ -51,11 +50,11 @@ export class Inject {
 
         try {
             if (input.flags.match("memo")) {
-                const tplInfo = await this.ctrl.config.getMemoInlineTemplate();
+                const tplInfo = await this.config.getMemoInlineTemplate();
                 const val = await this.buildInlineString(doc, tplInfo, ["${input}", input.text]);
                 return this.injectInlineString(val);
             } else if (input.flags.match(/task|todo/)) {
-                const tplInfo = await this.ctrl.config.getTaskInlineTemplate();
+                const tplInfo = await this.config.getTaskInlineTemplate();
                 const val = await this.buildInlineString(doc, tplInfo, ["${input}", input.text]);
                 return this.injectInlineString(val);
             } else {
@@ -63,7 +62,7 @@ export class Inject {
             }
         } catch (error) {
             if (error instanceof Error) {
-                this.ctrl.logger.error(error.message);
+                this.logger.error(error.message);
             }
             throw error;
         }
@@ -85,7 +84,7 @@ export class Inject {
      * Updates: Fix for  #55, always make sure there is a linebreak between the header and the injected text to stay markdown compliant
      */
     public async buildInlineString(doc: vscode.TextDocument, tpl: InlineTemplate, ...values: string[][]): Promise<InlineString> {
-        this.ctrl.logger.trace("Entering buildInlineString() in inject.ts with InlineTemplate: ", JSON.stringify(tpl), " and values ", JSON.stringify(values));
+        this.logger.trace("Entering buildInlineString() in inject.ts with InlineTemplate: ", JSON.stringify(tpl), " and values ", JSON.stringify(values));
 
         let content: string = tpl.value!;
         values.forEach((val: string[]) => {
@@ -149,10 +148,10 @@ export class Inject {
      * 
      */
     public async injectInlineString(content: InlineString, ...other: InlineString[]): Promise<vscode.TextDocument> {
-        this.ctrl.logger.trace("Entering injectInlineString() in inject.ts with string: ", content.value.trim());
+        this.logger.trace("Entering injectInlineString() in inject.ts with string: ", content.value.trim());
 
         if (isNullOrUndefined(content)) {
-            this.ctrl.logger.error("Content is null");
+            this.logger.error("Content is null");
             throw new Error("Invalid call, no reference to document due to null content.");
         }
 
@@ -167,13 +166,13 @@ export class Inject {
         }
 
         if (isNullOrUndefined(edit) || edit.size === 0) {
-            this.ctrl.logger.trace("No changes have been made to the document: ", content.document.fileName);
+            this.logger.trace("No changes have been made to the document: ", content.document.fileName);
             return content.document;
         }
 
         const applied = await vscode.workspace.applyEdit(edit);
         if (!applied) {
-            this.ctrl.logger.error("Failed inject inline string '", content.value, "'");
+            this.logger.error("Failed inject inline string '", content.value, "'");
             throw new Error("Failed to applied edit");
         }
         return content.document;
@@ -235,8 +234,8 @@ export class Inject {
      * @memberof Inject
      */
     public async formatNote(input: Input): Promise<string> {
-        this.ctrl.logger.trace("Entering formatNote() in inject.ts with input: ", JSON.stringify(input));
-        const headerTemplate: HeaderTemplate = await this.ctrl.config.getNotesTemplate(input.scope);
+        this.logger.trace("Entering formatNote() in inject.ts with input: ", JSON.stringify(input));
+        const headerTemplate: HeaderTemplate = await this.config.getNotesTemplate(input.scope);
         headerTemplate.value = headerTemplate.value!.replace('${input}', input.text);
         headerTemplate.value = headerTemplate.value!.replace('${tags}', input.tags.join(" ") + '\n');
 

--- a/src/actions/parser.ts
+++ b/src/actions/parser.ts
@@ -18,7 +18,7 @@
 'use strict';
 
 import * as Path from 'path';
-import { JournalController, Input } from '../model';
+import { IConfiguration, ILogger, Input } from '../model';
 import { isNullOrUndefined, isNotNullOrUndefined, normalizeFilename, getCurrentISOWeek, getISOWeekYear } from '../util';
 import { SCOPE_DEFAULT } from '../ext';
 import { MatchInput } from '../provider/features/match-input';
@@ -28,7 +28,7 @@ import { MatchInput } from '../provider/features/match-input';
  */
 export class Parser {
 
-    constructor(public ctrl: JournalController) {
+    constructor(private config: IConfiguration, private logger: ILogger) {
     }
 
     /**
@@ -44,49 +44,49 @@ export class Parser {
 
 
 
-        this.ctrl.logger.trace("Entering resolveNotePathForInput() in actions/parser.ts");
+        this.logger.trace("Entering resolveNotePathForInput() in actions/parser.ts");
 
         const date = new Date();
         input.scope = SCOPE_DEFAULT;
 
         input.text.match(/#\w+\s/g)?.forEach(tag => {
             if (isNullOrUndefined(tag) || tag!.length === 0) { return; }
-            this.ctrl.logger.trace("Tags in input string: " + tag);
+            this.logger.trace("Tags in input string: " + tag);
             input.tags.push(tag.trim().substring(0, tag.length - 1));
             input.text = input.text.replace(tag, " ");
-            this.ctrl.logger.trace("Scopes defined in configuration: " + this.ctrl.config.getScopes());
-            const scope: string | undefined = this.ctrl.config.getScopes().filter((name: string) => name === tag.trim().substring(1, tag.length)).pop();
+            this.logger.trace("Scopes defined in configuration: " + this.config.getScopes());
+            const scope: string | undefined = this.config.getScopes().filter((name: string) => name === tag.trim().substring(1, tag.length)).pop();
             if (isNotNullOrUndefined(scope) && scope!.length > 0) {
                 input.scope = scope!;
             }
-            this.ctrl.logger.trace("Identified scope in input: " + input.scope);
+            this.logger.trace("Identified scope in input: " + input.scope);
         });
 
         const inputForFileName = normalizeFilename(input.text);
-        const granularity = this.ctrl.config.getEntryGranularity(input.scope);
+        const granularity = this.config.getEntryGranularity(input.scope);
         const filePromise = granularity === "weekly"
-            ? this.ctrl.config.getWeeklyNotesFilePattern(
+            ? this.config.getWeeklyNotesFilePattern(
                 getCurrentISOWeek(date),
                 getISOWeekYear(date),
                 inputForFileName,
                 input.scope,
             )
-            : this.ctrl.config.getNotesFilePattern(date, inputForFileName, input.scope);
+            : this.config.getNotesFilePattern(date, inputForFileName, input.scope);
         const pathPromise = granularity === "weekly"
-            ? this.ctrl.config.getResolvedWeeklyNotesPath(
+            ? this.config.getResolvedWeeklyNotesPath(
                 getCurrentISOWeek(date),
                 getISOWeekYear(date),
                 input.scope,
             )
-            : this.ctrl.config.getResolvedNotesPath(date, input.scope);
+            : this.config.getResolvedNotesPath(date, input.scope);
 
         try {
             const [fileTemplate, pathTemplate] = await Promise.all([filePromise, pathPromise]);
             const path = Path.join(pathTemplate.value!, fileTemplate.value!.trim());
-            this.ctrl.logger.trace("Resolved path for note is", path);
+            this.logger.trace("Resolved path for note is", path);
             return path;
         } catch (error) {
-            this.ctrl.logger.error("Failed to resolve note path. Reason: ", error);
+            this.logger.error("Failed to resolve note path. Reason: ", error);
             throw error;
         }
 
@@ -103,9 +103,9 @@ export class Parser {
      */
     public async parseInput(inputString: string): Promise<Input> {
         let inputMatcher = new MatchInput(
-            this.ctrl.logger,
-            this.ctrl.config.getLocale(),
-            this.ctrl.config.getEntryGranularity(),
+            this.logger,
+            this.config.getLocale(),
+            this.config.getEntryGranularity(),
         );
         return inputMatcher.parseInput(inputString);
 

--- a/src/actions/reader.ts
+++ b/src/actions/reader.ts
@@ -19,13 +19,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { JournalController, Input } from '../model';
+import { IConfiguration, IDialogues, ILogger, IWriter, Input } from '../model';
 import { isNullOrUndefined, resolvePath, fileExists } from '../util';
 
 export class Reader {
     public onNotesInjected?: (doc: vscode.TextDocument, date: Date) => void;
 
-    constructor(public ctrl: JournalController) {
+    constructor(private config: IConfiguration, private logger: ILogger, private writer: IWriter, private ui: IDialogues) {
     }
 
 
@@ -55,19 +55,19 @@ export class Reader {
      * @param week the week of the current year
      */
     public async loadEntryForWeek(week: Number, scope?: string): Promise<vscode.TextDocument> {
-        this.ctrl.logger.trace("Entering loadEntryForWeek() in actions/reader.ts for week " + week);
+        this.logger.trace("Entering loadEntryForWeek() in actions/reader.ts for week " + week);
 
         const [pathname, filename] = await Promise.all([
-            this.ctrl.config.getWeekPathPattern(week, scope),
-            this.ctrl.config.getWeekFilePattern(week, scope),
+            this.config.getWeekPathPattern(week, scope),
+            this.config.getWeekFilePattern(week, scope),
         ]);
         const path = resolvePath(pathname.value!, filename.value!);
 
         const doc = await this.openOrCreate(
             path,
-            () => this.ctrl.writer.createWeeklyForPath(path, week),
+            () => this.writer.createWeeklyForPath(path, week),
         );
-        this.ctrl.logger.debug("loadEntryForWeek() - Loaded file in:", doc.uri.toString());
+        this.logger.debug("loadEntryForWeek() - Loaded file in:", doc.uri.toString());
         return doc;
     }
 
@@ -83,19 +83,19 @@ export class Reader {
         if (isNullOrUndefined(date) || date!.toString().includes("Invalid")) {
             throw new Error("Invalid date");
         }
-        this.ctrl.logger.trace("Entering loadEntryforDate() in actions/reader.ts for date " + date.toISOString());
+        this.logger.trace("Entering loadEntryforDate() in actions/reader.ts for date " + date.toISOString());
 
         const [pathname, filename] = await Promise.all([
-            this.ctrl.config.getResolvedEntryPath(date, scope),
-            this.ctrl.config.getEntryFilePattern(date, scope),
+            this.config.getResolvedEntryPath(date, scope),
+            this.config.getEntryFilePattern(date, scope),
         ]);
         const path = resolvePath(pathname.value!, filename.value!);
 
         const doc = await this.openOrCreate(
             path,
-            () => this.ctrl.writer.createEntryForPath(path, date),
+            () => this.writer.createEntryForPath(path, date),
         );
-        this.ctrl.logger.debug("loadEntryForDate() - Loaded file in:", doc.uri.toString());
+        this.logger.debug("loadEntryForDate() - Loaded file in:", doc.uri.toString());
 
         this.onNotesInjected?.(doc, date);
 
@@ -108,7 +108,7 @@ export class Reader {
     ): Promise<vscode.TextDocument> {
         const exists = await fileExists(vscode.Uri.file(path));
         if (exists) {
-            return this.ctrl.ui.openDocument(path);
+            return this.ui.openDocument(path);
         }
         return create();
     }

--- a/src/actions/writer.ts
+++ b/src/actions/writer.ts
@@ -19,16 +19,16 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { JournalController } from '../model';
+import { IConfiguration, IInject, ILogger } from '../model';
 
-/** 
- * Anything which modifies the text documents goes here. 
- * 
+/**
+ * Anything which modifies the text documents goes here.
+ *
  */
 export class Writer {
 
 
-    constructor(public ctrl: JournalController) {
+    constructor(private config: IConfiguration, private logger: ILogger, private inject: IInject) {
     }
 
     public async saveDocument(doc: vscode.TextDocument): Promise<vscode.TextDocument> {
@@ -41,7 +41,7 @@ export class Writer {
      * Adds the given content at the start of text document
      */
     public async writeHeader(doc: vscode.TextDocument, content: string): Promise<vscode.TextDocument> {
-        return this.ctrl.inject.injectString(doc, content, new vscode.Position(0, 0));
+        return this.inject.injectString(doc, content, new vscode.Position(0, 0));
     }
 
 
@@ -56,8 +56,8 @@ export class Writer {
      * @memberof Writer
      */
     public async createEntryForPath(path: string, date: Date): Promise<vscode.TextDocument> {
-        this.ctrl.logger.trace("Entering createEntryForPath() in ext/writer.ts for path: ", path);
-        const tpl = await this.ctrl.config.getEntryTemplate(date);
+        this.logger.trace("Entering createEntryForPath() in ext/writer.ts for path: ", path);
+        const tpl = await this.config.getEntryTemplate(date);
         const content = tpl.value || "";
         return this.createSaveLoadTextDocument(path, content);
     }
@@ -71,8 +71,8 @@ export class Writer {
      * @memberof Writer
      */
     public async createWeeklyForPath(path: string, week: Number): Promise<vscode.TextDocument> {
-        this.ctrl.logger.trace("Entering createWeeklyForPath() in ext/writer.ts for path: ", path);
-        const tpl = await this.ctrl.config.getWeeklyTemplate(week);
+        this.logger.trace("Entering createWeeklyForPath() in ext/writer.ts for path: ", path);
+        const tpl = await this.config.getWeeklyTemplate(week);
         const content = tpl.value || "";
         return this.createSaveLoadTextDocument(path, content);
     }
@@ -86,7 +86,7 @@ export class Writer {
      */
     public async createSaveLoadTextDocument(path: string, content: string): Promise<vscode.TextDocument> {
 
-        this.ctrl.logger.trace("Entering createSaveLoadTextDocument() in ext/writer.ts for path: ", path);
+        this.logger.trace("Entering createSaveLoadTextDocument() in ext/writer.ts for path: ", path);
 
         const fileUri = vscode.Uri.file(path);
         const encoder = new TextEncoder();
@@ -96,7 +96,7 @@ export class Writer {
 
         // Open the persisted document
         const doc = await vscode.workspace.openTextDocument(fileUri);
-        this.ctrl.logger.debug("Opened new file with name: ", doc.fileName);
+        this.logger.debug("Opened new file with name: ", doc.fileName);
         return doc;
 
     }

--- a/src/ext/dialogues.ts
+++ b/src/ext/dialogues.ts
@@ -23,7 +23,7 @@ import * as Path from 'path';
 import { isNotNullOrUndefined, isString, isError, stringIsNotEmpty, denormalizeFilename } from '../util';
 import { SCOPE_DEFAULT } from './conf';
 import moment = require('moment');
-import { JournalController, JournalPageType, Input, ScopeDirectory, NoteInput, SelectedInput, FileEntry } from '../model';
+import { IConfiguration, ILogger, IParser, JournalPageType, Input, ScopeDirectory, NoteInput, SelectedInput, FileEntry } from '../model';
 import { sortPickEntries, ScanEntries, TimedQuickPick, DecoratedQuickPickItem } from '../provider/features/scan-entries';
 
 
@@ -37,8 +37,8 @@ export class Dialogues {
 
     private scanner: ScanEntries;
 
-    constructor(public ctrl: JournalController) {
-        this.scanner = new ScanEntries(this.ctrl);
+    constructor(private config: IConfiguration, private logger: ILogger, private parser: IParser) {
+        this.scanner = new ScanEntries(config, logger);
     }
 
     public getScanner(): ScanEntries {
@@ -80,7 +80,7 @@ export class Dialogues {
                         }
                         return;
                     } else {
-                        this.ctrl.parser.parseInput(val).then((parsed: Input) => {
+                        this.parser.parseInput(val).then((parsed: Input) => {
                             // this is the placeholder, which gets continuously updated when the user types in anything
                             let item: DecoratedQuickPickItem = {
                                 label: val,
@@ -90,7 +90,6 @@ export class Dialogues {
                                 replace: true,
                                 description: this.generateDescription(parsed),
                                 detail: this.generateDetail(parsed)
-                                // detail: parsed.generateDetail(this.ctrl.config)
                             };
 
                             if (input.items[0].replace && input.items[0].replace === true) {
@@ -99,7 +98,7 @@ export class Dialogues {
                                 input.items = [item].concat(input.items);
                             }
                         }).catch(error => {
-                            this.ctrl.logger.trace("Warning: " + error);
+                            this.logger.trace("Warning: " + error);
                             // do nothin
                         });
                     }
@@ -132,12 +131,12 @@ export class Dialogues {
                             resolve(selected);
                         });
                     } else {
-                        this.ctrl.parser.parseInput(selected.label).then(resolve);
+                        this.parser.parseInput(selected.label).then(resolve);
                     }
                 }, disposables);
 
             } catch (error) {
-                this.ctrl.logger.error("Failed to get user input", error);
+                this.logger.error("Failed to get user input", error);
                 reject(error);
             } finally {
                 disposables.forEach(d => d.dispose());
@@ -148,7 +147,7 @@ export class Dialogues {
 
 
     private generateDescription(parsed: Input): string {
-        moment.locale(this.ctrl.config.getLocale());
+        moment.locale(this.config.getLocale());
 
         let date = new Date();
         date.setDate(date.getDate() + parsed.offset);
@@ -157,13 +156,13 @@ export class Dialogues {
 
 
     private generateDetail(parsed: Input): string {
-        moment.locale(this.ctrl.config.getLocale());
+        moment.locale(this.config.getLocale());
 
         let date = new Date();
         date.setDate(date.getDate() + parsed.offset);
         let t: moment.Moment = moment(date);
 
-        let time: string = t.calendar(moment(), this.ctrl.config.getInputDetailsTimeFormat());
+        let time: string = t.calendar(moment(), this.config.getInputDetailsTimeFormat());
 
         if (parsed.hasWeek() && !parsed.hasTask()) {
             return vscode.l10n.t("Open notes for week {week}", { week: parsed.week });
@@ -186,19 +185,19 @@ export class Dialogues {
 
 
         let baseDirectories: ScopeDirectory[] = [];
-        this.ctrl.config.getScopes().forEach(scope => {
-            // let dir = this.ctrl.config.getBasePath(scope); 
+        this.config.getScopes().forEach(scope => {
+            // let dir = this.config.getBasePath(scope); 
             let pattern = "";
 
             if (type === JournalPageType.entry) {
-                pattern = this.ctrl.config.getEntryPathPattern(scope);
+                pattern = this.config.getEntryPathPattern(scope);
             }
             else if (type === JournalPageType.note) {
-                pattern = this.ctrl.config.getNotesPathPattern(scope);
+                pattern = this.config.getNotesPathPattern(scope);
             }
 
             // replace base and resolve
-            pattern = pattern.replace("${base}", this.ctrl.config.getBasePath(scope));
+            pattern = pattern.replace("${base}", this.config.getBasePath(scope));
             pattern = Path.normalize(pattern);
 
             // stop when date variables appear in path
@@ -250,7 +249,7 @@ export class Dialogues {
                 // collect directories to scan (including in scopes)
                 const directories = this.collectScanDirectories(type);
 
-                this.scanner.getPreviouslyAccessedFiles(this.ctrl.config.getInputTimeThreshold(), addItemToPickList, input, type, directories);
+                this.scanner.getPreviouslyAccessedFiles(this.config.getInputTimeThreshold(), addItemToPickList, input, type, directories);
                 input.show();
                 input.onDidChangeSelection(sel => {
                     selected = sel[0];
@@ -269,10 +268,10 @@ export class Dialogues {
                             inputText.text = val;
 
 
-                            this.ctrl.parser.resolveNotePathForInput(inputText).then(path => {
+                            this.parser.resolveNotePathForInput(inputText).then(path => {
                                 inputText.path = path;
 
-                                this.ctrl.logger.debug("Tags in input string: [" + ((inputText.tags.length === 0) ? "" : inputText.tags) + "] and scope " + inputText.scope);
+                                this.logger.debug("Tags in input string: [" + ((inputText.tags.length === 0) ? "" : inputText.tags) + "] and scope " + inputText.scope);
 
                                 // infer description
                                 let description: string = "";
@@ -320,7 +319,7 @@ export class Dialogues {
                 }, disposables);
 
             } catch (error) {
-                this.ctrl.logger.error("Failed to pick item", error);
+                this.logger.error("Failed to pick item", error);
                 reject(error);
             } finally {
                 disposables.forEach(d => d.dispose());
@@ -335,12 +334,12 @@ export class Dialogues {
      * Simple method to have Q Promise for vscode API call to get user input 
      */
     public async getUserInput(tip: string): Promise<string> {
-        this.ctrl.logger.trace("Entering getUserInput() in ext/vscode.ts");
+        this.logger.trace("Entering getUserInput() in ext/vscode.ts");
         const value = await vscode.window.showInputBox({ prompt: tip });
         if (isNotNullOrUndefined(value) && value!.length > 0) {
             return value!;
         }
-        this.ctrl.logger.debug("User canceled");
+        this.logger.debug("User canceled");
         throw new Error("cancel");
     }
 
@@ -367,7 +366,7 @@ export class Dialogues {
      * @memberOf VsCode
      */
     public async showDocument(textDocument: vscode.TextDocument): Promise<vscode.TextEditor> {
-        this.ctrl.logger.trace("Entering showDocument() in ext/vscode.ts for document: ", textDocument.fileName);
+        this.logger.trace("Entering showDocument() in ext/vscode.ts for document: ", textDocument.fileName);
 
         if (textDocument.isDirty) { textDocument.save(); }
 
@@ -375,11 +374,11 @@ export class Dialogues {
             editor => textDocument.fileName.startsWith(editor.document.fileName)
         );
         if (existingEditor) {
-            this.ctrl.logger.debug("Document  ", textDocument.fileName, " is already opened.");
+            this.logger.debug("Document  ", textDocument.fileName, " is already opened.");
             return existingEditor;
         }
 
-        const col = this.ctrl.config.isOpenInNewEditorGroup() ? 2 : 1;
+        const col = this.config.isOpenInNewEditorGroup() ? 2 : 1;
         const view = await vscode.window.showTextDocument(textDocument, col, false);
 
         vscode.commands.executeCommand("cursorMove", {
@@ -388,7 +387,7 @@ export class Dialogues {
             value: textDocument.lineCount
         });
 
-        this.ctrl.logger.debug("Showed document  ", textDocument.fileName);
+        this.logger.debug("Showed document  ", textDocument.fileName);
         return view;
     }
 
@@ -408,7 +407,7 @@ export class Dialogues {
         let hint = "Open the logs to see details.";
         vscode.window.showErrorMessage(errorMessage, hint)
             .then(clickedHint => {
-                this.ctrl.logger.showChannel();
+                this.logger.showChannel();
             });
     }
 }

--- a/src/ext/startup.ts
+++ b/src/ext/startup.ts
@@ -71,7 +71,8 @@ export class Startup {
     public async registerLoggingChannel(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<J.Util.Ctrl> {
         const channel: vscode.OutputChannel = vscode.window.createOutputChannel("Journal");
         context.subscriptions.push(channel);
-        ctrl.logger = new J.Util.ConsoleLogger(ctrl, channel);
+        const logger = new J.Util.ConsoleLogger(ctrl.config, channel);
+        ctrl.initServices(logger);
         ctrl.logger.debug("VSCode Journal is starting");
         return ctrl;
     }

--- a/src/provider/features/scan-entries.ts
+++ b/src/provider/features/scan-entries.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import * as Path from 'path';
 import { SCOPE_DEFAULT } from '../../ext';
-import { FileEntry, JournalController } from '../../model';
+import { FileEntry, IConfiguration, ILogger } from '../../model';
 
 export interface DecoratedQuickPickItem extends vscode.QuickPickItem {
     parsedInput?: J.Model.Input;
@@ -25,7 +25,7 @@ export interface TimedQuickPick extends vscode.QuickPick<DecoratedQuickPickItem>
 export class ScanEntries {
 
     private cache: Map<String, J.Model.FileEntry>;
-    constructor(public ctrl: JournalController) {
+    constructor(private config: IConfiguration, private logger: ILogger) {
         this.cache = new Map();
     }
 
@@ -47,7 +47,7 @@ export class ScanEntries {
      */
     public async getPreviouslyAccessedFilesSync(thresholdInMs: number, directories: J.Model.ScopeDirectory[]): Promise<J.Model.FileEntry[]> {
 
-        this.ctrl.logger.trace("Entering getPreviousJournalFilesSync() in actions/reader.ts");
+        this.logger.trace("Entering getPreviousJournalFilesSync() in actions/reader.ts");
 
         if (this.cache.size > 0) {
             return Array.from(this.cache.values()).sort(sortPickEntries);
@@ -59,13 +59,13 @@ export class ScanEntries {
             try {
                 await vscode.workspace.fs.stat(vscode.Uri.file(directory.path));
             } catch {
-                this.ctrl.logger.error("Invalid configuration, base directory does not exist with path", directory.path);
+                this.logger.error("Invalid configuration, base directory does not exist with path", directory.path);
                 continue;
             }
 
             await this.walkDir(directory.path, thresholdInMs, (entries: J.Model.FileEntry[]) => {
                 entries.forEach(entry => {
-                    entry.type = J.Util.inferType(Path.parse(entry.path), this.ctrl.config.getFileExtension());
+                    entry.type = J.Util.inferType(Path.parse(entry.path), this.config.getFileExtension());
                     entry.scope = directory.scope;
                     this.cache.set(entry.path, entry);
                 });
@@ -92,7 +92,7 @@ export class ScanEntries {
         // for each file, check if it is an entry, a note or an attachement
 
 
-        this.ctrl.logger.trace("Entering getPreviouslyAccessedFiles() in actions/reader.ts and number of directories to scan: ", directories.size);
+        this.logger.trace("Entering getPreviouslyAccessedFiles() in actions/reader.ts and number of directories to scan: ", directories.size);
 
         // Cache short-circuit (#187): if we have already scanned, return cached entries and
         // skip the filesystem walk entirely. Cache is invalidated explicitly via clearCache()
@@ -131,13 +131,13 @@ export class ScanEntries {
         try {
             await vscode.workspace.fs.stat(vscode.Uri.file(directory.path));
         } catch {
-            this.ctrl.logger.error("Invalid configuration, base directory does not exist");
+            this.logger.error("Invalid configuration, base directory does not exist");
             return;
         }
 
         await this.walkDir(directory.path, thresholdInMs, (entries: J.Model.FileEntry[]) => {
             entries.forEach(fe => {
-                fe.type = J.Util.inferType(Path.parse(fe.path), this.ctrl.config.getFileExtension());
+                fe.type = J.Util.inferType(Path.parse(fe.path), this.config.getFileExtension());
                 fe.scope = directory.scope;
                 if (!this.cache.has(fe.path)) {
                     this.cache.set(fe.path, fe);

--- a/src/test/suite/commands-entry.test.ts
+++ b/src/test/suite/commands-entry.test.ts
@@ -17,7 +17,7 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
     const refreshed = vscode.workspace.getConfiguration('journal');
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 

--- a/src/test/suite/commands-inject.test.ts
+++ b/src/test/suite/commands-inject.test.ts
@@ -11,7 +11,7 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
     const refreshed = vscode.workspace.getConfiguration('journal');
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 

--- a/src/test/suite/commands-note.test.ts
+++ b/src/test/suite/commands-note.test.ts
@@ -13,7 +13,7 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
     const refreshed = vscode.workspace.getConfiguration('journal');
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 

--- a/src/test/suite/commands-prev-next.test.ts
+++ b/src/test/suite/commands-prev-next.test.ts
@@ -40,7 +40,7 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
     } while (Date.now() < deadline);
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 

--- a/src/test/suite/commands-weekly.test.ts
+++ b/src/test/suite/commands-weekly.test.ts
@@ -12,7 +12,7 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
     const refreshed = vscode.workspace.getConfiguration('journal');
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 

--- a/src/test/suite/input.test.ts
+++ b/src/test/suite/input.test.ts
@@ -19,11 +19,10 @@ suite('Open Journal Entries', () => {
 	test("Input '+1'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("+1");
+		let input = await ctrl.parser.parseInput("+1");
 
 
 		assert.strictEqual(1, input.offset);
@@ -33,11 +32,10 @@ suite('Open Journal Entries', () => {
 	test("Input '2021-05-12'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("2021-05-12");
+		let input = await ctrl.parser.parseInput("2021-05-12");
 
 		assert.strictEqual(input.offset > 0 || input.offset <= 0, true);
 	})
@@ -46,11 +44,10 @@ suite('Open Journal Entries', () => {
 	test("Input '05-12'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("05-12");
+		let input = await ctrl.parser.parseInput("05-12");
 
 		assert.strictEqual(input.offset > 0 || input.offset <= 0, true);
 	})
@@ -59,11 +56,10 @@ suite('Open Journal Entries', () => {
 	test("Input '12'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("12");
+		let input = await ctrl.parser.parseInput("12");
 
 		assert.strictEqual(input.offset > 0 || input.offset <= 0, true);
 	})
@@ -72,11 +68,10 @@ suite('Open Journal Entries', () => {
 	test("Input 'next monday'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("next monday");
+		let input = await ctrl.parser.parseInput("next monday");
 
 
 		assert.ok(input.offset > 0, "Offset not > 0, is " + input.offset);
@@ -85,11 +80,10 @@ suite('Open Journal Entries', () => {
 	test("Input 'next tue'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("next tue");
+		let input = await ctrl.parser.parseInput("next tue");
 
 		assert.ok(input.offset > 0, "Offset not > 0, is " + input.offset);
 	});
@@ -97,11 +91,10 @@ suite('Open Journal Entries', () => {
 	test("Input 'last wed'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("last wed");
+		let input = await ctrl.parser.parseInput("last wed");
 
 		assert.ok(input.offset < 0, "Offset not < 0, is " + input.offset);
 	});
@@ -110,11 +103,10 @@ suite('Open Journal Entries', () => {
 	test("Input 'task +1 do this'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("task +1 text");
+		let input = await ctrl.parser.parseInput("task +1 text");
 
 		assert.ok(input.offset > 0, "Offset not > 0, is " + input.offset);
 		assert.ok(input.hasFlags(), "Input has no flags " + JSON.stringify(input));
@@ -125,11 +117,10 @@ suite('Open Journal Entries', () => {
 	test("Input 'task next wed do this'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("task next wed text");
+		let input = await ctrl.parser.parseInput("task next wed text");
 
 		assert.ok(input.offset > 0, "Offset not > 0, is " + input.offset);
 		assert.ok(input.hasFlags(), "Input has no flags " + JSON.stringify(input));
@@ -146,9 +137,8 @@ suite('Issue #170 — weekday/month/shortcut prefix collisions', () => {
 	async function parse(text: string): Promise<J.Model.Input> {
 		const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		const ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
-		const parser = new J.Actions.Parser(ctrl);
-		return parser.parseInput(text);
+		ctrl.initServices(new TestLogger(false));
+		return ctrl.parser.parseInput(text);
 	}
 
 	// Negative tests — free-text input must NOT match a token prefix

--- a/src/test/suite/issue-168-entry-granularity.test.ts
+++ b/src/test/suite/issue-168-entry-granularity.test.ts
@@ -16,7 +16,7 @@ async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
     const refreshed = vscode.workspace.getConfiguration('journal');
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 

--- a/src/test/suite/issue-185-weekly-sync.test.ts
+++ b/src/test/suite/issue-185-weekly-sync.test.ts
@@ -18,7 +18,7 @@ async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
     const refreshed = vscode.workspace.getConfiguration('journal');
     const ctrl = new J.Util.Ctrl(refreshed);
     const logger = new TestLogger(false);
-    ctrl.logger = logger;
+    ctrl.initServices(logger);
     return { ctrl, logger };
 }
 
@@ -165,7 +165,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
             await config.update('weeklySync', { enabled: true, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'descending' }, vscode.ConfigurationTarget.Workspace);
             const refreshed = vscode.workspace.getConfiguration('journal');
             const descCtrl = new J.Util.Ctrl(refreshed);
-            descCtrl.logger = ctrl.logger;
+            descCtrl.initServices(ctrl.logger);
 
             try {
                 const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
@@ -269,7 +269,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
             await config.update('weeklySync', { enabled: false, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'ascending' }, vscode.ConfigurationTarget.Workspace);
             const refreshed = vscode.workspace.getConfiguration('journal');
             const disabledCtrl = new J.Util.Ctrl(refreshed);
-            disabledCtrl.logger = logger;
+            disabledCtrl.initServices(logger);
 
             const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
             await writeFile(monUri, '');

--- a/src/test/suite/issue-51-remote-create.test.ts
+++ b/src/test/suite/issue-51-remote-create.test.ts
@@ -47,7 +47,7 @@ suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
             const refreshedConfig = vscode.workspace.getConfiguration('journal');
             ctrl = new J.Util.Ctrl(refreshedConfig);
             logger = new TestLogger(false);
-            ctrl.logger = logger;
+            ctrl.initServices(logger);
 
             openCallCount = 0;
             const original = ctrl.ui.openDocument.bind(ctrl.ui);

--- a/src/test/suite/notes-sync.test.ts
+++ b/src/test/suite/notes-sync.test.ts
@@ -15,7 +15,7 @@ suite('Test Notes Syncing', () => {
 
         let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
         let ctrl = new J.Util.Ctrl(config);
-        ctrl.logger = new TestLogger(false);
+        ctrl.initServices(new TestLogger(false));
 
         // create a new entry.. remember length
         await vscode.commands.executeCommand("journal.today");

--- a/src/test/suite/phase1-regression.test.ts
+++ b/src/test/suite/phase1-regression.test.ts
@@ -96,7 +96,7 @@ suite('Phase 1 — Regression Tests', () => {
         test('createSaveLoadTextDocument writes and opens a file via vscode.workspace.fs', async () => {
             const config = vscode.workspace.getConfiguration("journal");
             const ctrl = new J.Util.Ctrl(config);
-            ctrl.logger = new TestLogger(false);
+            ctrl.initServices(new TestLogger(false));
 
             const tmpDir = require('os').tmpdir();
             const testPath = require('path').join(tmpDir, `journal-test-${Date.now()}.md`);

--- a/src/test/suite/read-templates.test.ts
+++ b/src/test/suite/read-templates.test.ts
@@ -42,7 +42,7 @@ suite('Read templates from configuration', () => {
         ], vscode.ConfigurationTarget.Workspace);
         config = vscode.workspace.getConfiguration('journal');
         ctrl = new J.Util.Ctrl(config);
-        ctrl.logger = new TestLogger(false);
+        ctrl.initServices(new TestLogger(false));
     });
 
     afterEach(async () => {

--- a/src/test/suite/scan-entries-cache.test.ts
+++ b/src/test/suite/scan-entries-cache.test.ts
@@ -40,8 +40,8 @@ suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
 
         const refreshed = vscode.workspace.getConfiguration('journal');
         ctrl = new J.Util.Ctrl(refreshed);
-        ctrl.logger = new TestLogger(false);
-        scanner = new ScanEntries(ctrl);
+        ctrl.initServices(new TestLogger(false));
+        scanner = new ScanEntries(ctrl.config, ctrl.logger);
 
         walkCount = 0;
         originalWalkDir = (ScanEntries.prototype as any).walkDir;

--- a/src/test/suite/week-input.test.ts
+++ b/src/test/suite/week-input.test.ts
@@ -16,14 +16,13 @@ suite('Open Week Entries', () => {
 	before(() => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
 	});
 
 	test("Input 'w13'", async () => {
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("w13");
+		let input = await ctrl.parser.parseInput("w13");
 
 		assert.ok(!input.hasOffset(), "Offset is set, is " + input.offset);
 		assert.ok(!input.hasFlags(), "Input has flags " + JSON.stringify(input));
@@ -36,10 +35,9 @@ suite('Open Week Entries', () => {
 	test("Input 'w'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
-		let parser = new J.Actions.Parser(ctrl);
-		let input = await parser.parseInput("w");
+		let input = await ctrl.parser.parseInput("w");
 
 		assert.ok(!input.hasOffset(), "Offset is set, is " + input.offset);
 		assert.ok(!input.hasFlags(), "Input has flags " + JSON.stringify(input));
@@ -52,11 +50,10 @@ suite('Open Week Entries', () => {
 	test("Input 'next week'", async () => {
 		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
 		let ctrl = new J.Util.Ctrl(config);
-		ctrl.logger = new TestLogger(false);
+		ctrl.initServices(new TestLogger(false));
 
-		let parser = new J.Actions.Parser(ctrl);
-		const thisWeekInput = await parser.parseInput("w");
-		const nextWeekInput = await parser.parseInput("next week");
+		const thisWeekInput = await ctrl.parser.parseInput("w");
+		const nextWeekInput = await ctrl.parser.parseInput("next week");
 
 		assert.ok(!nextWeekInput.hasOffset(), "Offset is set, is " + nextWeekInput.offset);
 		assert.ok(!nextWeekInput.hasFlags(), "Input has flags " + JSON.stringify(nextWeekInput));

--- a/src/util/controller.ts
+++ b/src/util/controller.ts
@@ -22,31 +22,35 @@
 
 import * as J from '../.';
 import * as vscode from 'vscode';
-import { JournalController } from '../model';
+import { ILogger, JournalController } from '../model';
+import { Parser } from '../actions/parser';
+import { Writer } from '../actions/writer';
+import { Reader } from '../actions/reader';
+import { Inject } from '../actions/inject';
+import { Dialogues } from '../ext/dialogues';
 
 export class Ctrl implements JournalController {
 
 
     private _config: J.Extension.Configuration;
-    private _ui: J.Extension.Dialogues;
-    private _parser: J.Actions.Parser;
-    private _writer: J.Actions.Writer;
-    private _reader: J.Actions.Reader;
+    private _ui!: J.Extension.Dialogues;
+    private _parser!: J.Actions.Parser;
+    private _writer!: J.Actions.Writer;
+    private _reader!: J.Actions.Reader;
+    private _logger: J.Util.Logger | undefined;
+    private _inject!: J.Actions.Inject;
 
- 
-    private _logger: J.Util.Logger | undefined; 
-
-
-    private _inject: J.Actions.Inject;
-
-    
     constructor(vscodeConfig: vscode.WorkspaceConfiguration) {
         this._config = new J.Extension.Configuration(vscodeConfig);
-        this._parser = new J.Actions.Parser(this);
-        this._writer = new J.Actions.Writer(this);
-        this._reader = new J.Actions.Reader(this);
-        this._inject = new J.Actions.Inject(this);
-        this._ui = new J.Extension.Dialogues(this);
+    }
+
+    public initServices(logger: ILogger): void {
+        this._logger = logger as J.Util.Logger;
+        this._inject = new Inject(this._config, logger);
+        this._writer = new Writer(this._config, logger, this._inject);
+        this._parser = new Parser(this._config, logger);
+        this._ui = new Dialogues(this._config, logger, this._parser);
+        this._reader = new Reader(this._config, logger, this._writer, this._ui);
     }
 
 
@@ -106,14 +110,6 @@ export class Ctrl implements JournalController {
 	public get logger(): J.Util.Logger  {
         if(J.Util.isNullOrUndefined(this._logger)) { throw Error("Tried to access undefined logger in journal"); } 
 		return this._logger!;
-	}
-
-    /**
-     * Setter logger
-     * @param {J.Util.Logger} value
-     */
-	public set logger(value: J.Util.Logger) {
-		this._logger = value;
 	}
 
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -18,7 +18,7 @@
 
 
 import * as vscode from 'vscode';
-import { JournalController } from '../model';
+import { IConfiguration } from '../model';
 import { isString } from './strings';
 import { isError, isNotNullOrUndefined } from './util';
 
@@ -36,8 +36,8 @@ export class ConsoleLogger implements Logger {
     private devMode = false; 
 
 
-    constructor(public ctrl: JournalController, public channel: vscode.OutputChannel) {
-        this.devMode = ctrl.config.isDevelopmentModeEnabled();
+    constructor(private config: IConfiguration, public channel: vscode.OutputChannel) {
+        this.devMode = config.isDevelopmentModeEnabled();
     }
 
     public showChannel(): void {


### PR DESCRIPTION
## Summary

- Replace `constructor(public ctrl: JournalController)` with narrow sub-interface params in all seven action/UI modules (`Inject`, `Parser`, `Writer`, `Reader`, `Dialogues`, `ConsoleLogger`, `ScanEntries`)
- `Ctrl` becomes a two-phase object: constructor creates `Configuration` only; `initServices(logger: ILogger)` creates all services in dependency order
- 14 test files updated from `ctrl.logger = logger` to `ctrl.initServices(logger)`; `new J.Actions.Parser(ctrl)` calls replaced by `ctrl.parser`

## Test plan

- [ ] `npm run compile` — zero errors
- [ ] `npm run lint` — zero new warnings
- [ ] `npm test` — 126 tests pass (verified locally)
- [ ] `grep -rn "this\.ctrl" src/actions/ src/ext/dialogues.ts src/util/logger.ts src/provider/features/scan-entries.ts` — no output (verified)

## Related

- Implements approved plan: [docs/plans/2026-05-17-208-constructor-injection.md](../blob/feat/208-constructor-injection/docs/plans/2026-05-17-208-constructor-injection.md)
- Spec: [docs/specs/2026-05-17-208-constructor-injection.md](../blob/feat/208-constructor-injection/docs/specs/2026-05-17-208-constructor-injection.md)
- Closes #208
- Builds on #207 (merged as #213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)