### PR TITLE
refactor(domain): enrich NoteInput with extractScopeAndTags (#210)

### DIFF
--- a/src/commands/show-note.ts
+++ b/src/commands/show-note.ts
@@ -48,9 +48,9 @@ export class ShowNoteCommand implements vscode.Command, vscode.Disposable {
 
         try {
             const userInput: string = await this.ctrl.ui.getUserInput("Enter title for new note");
-            let parsedInput: J.Model.Input = await this.ctrl.parser.parseInput(userInput); 
-            
-            const doc : vscode.TextDocument = await new J.Features.LoadNotes(parsedInput, this.ctrl).load();
+            let parsedInput: J.Model.Input = await this.ctrl.parser.parseInput(userInput);
+
+            const doc: vscode.TextDocument = await new J.Features.LoadNotes(parsedInput as J.Model.NoteInput, this.ctrl).load();
             await this.ctrl.ui.showDocument(doc);
 
            

--- a/src/features/entries/load-note.ts
+++ b/src/features/entries/load-note.ts
@@ -8,7 +8,7 @@ import * as J from '../..';
  
 export class LoadNotes {
 
-    constructor(public input: J.Model.Input, public ctrl: J.Util.Ctrl) {
+    constructor(public input: J.Model.NoteInput, public ctrl: J.Util.Ctrl) {
 
     }
 

--- a/src/journal/parser.ts
+++ b/src/journal/parser.ts
@@ -18,9 +18,8 @@
 'use strict';
 
 import * as Path from 'path';
-import { IConfiguration, ILogger, Input } from '../model';
-import { isNullOrUndefined, isNotNullOrUndefined, normalizeFilename, getCurrentISOWeek, getISOWeekYear } from '../util';
-import { SCOPE_DEFAULT } from '../vscode';
+import { IConfiguration, ILogger, Input, NoteInput } from '../model';
+import { normalizeFilename, getCurrentISOWeek, getISOWeekYear } from '../util';
 import { MatchInput } from './match-input';
 
 /**
@@ -47,20 +46,8 @@ export class Parser {
         this.logger.trace("Entering resolveNotePathForInput() in actions/parser.ts");
 
         const date = new Date();
-        input.scope = SCOPE_DEFAULT;
-
-        input.text.match(/#\w+\s/g)?.forEach(tag => {
-            if (isNullOrUndefined(tag) || tag!.length === 0) { return; }
-            this.logger.trace("Tags in input string: " + tag);
-            input.tags.push(tag.trim().substring(0, tag.length - 1));
-            input.text = input.text.replace(tag, " ");
-            this.logger.trace("Scopes defined in configuration: " + this.config.getScopes());
-            const scope: string | undefined = this.config.getScopes().filter((name: string) => name === tag.trim().substring(1, tag.length)).pop();
-            if (isNotNullOrUndefined(scope) && scope!.length > 0) {
-                input.scope = scope!;
-            }
-            this.logger.trace("Identified scope in input: " + input.scope);
-        });
+        (input as NoteInput).extractScopeAndTags(this.config.getScopes());
+        this.logger.trace("Tags in input: " + input.tags + ", scope: " + input.scope);
 
         const inputForFileName = normalizeFilename(input.text);
         const granularity = this.config.getEntryGranularity(input.scope);

--- a/src/journal/parser.ts
+++ b/src/journal/parser.ts
@@ -18,7 +18,7 @@
 'use strict';
 
 import * as Path from 'path';
-import { IConfiguration, ILogger, Input, NoteInput } from '../model';
+import { IConfiguration, ILogger, Input } from '../model';
 import { normalizeFilename, getCurrentISOWeek, getISOWeekYear } from '../util';
 import { MatchInput } from './match-input';
 
@@ -46,7 +46,7 @@ export class Parser {
         this.logger.trace("Entering resolveNotePathForInput() in actions/parser.ts");
 
         const date = new Date();
-        (input as NoteInput).extractScopeAndTags(this.config.getScopes());
+        input.extractScopeAndTags(this.config.getScopes());
         this.logger.trace("Tags in input: " + input.tags + ", scope: " + input.scope);
 
         const inputForFileName = normalizeFilename(input.text);

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -32,3 +32,5 @@ export type EntryGranularity = "daily" | "weekly";
 export type NavigationMode = 'existing' | 'calendar';
 export interface ScopeDefinitionLite { name?: string; base?: string; }
 export type InputDetailsTimeFormat = { sameDay: string; nextDay: string; nextWeek: string; lastDay: string; lastWeek: string; sameElse: string; };
+
+export const SCOPE_DEFAULT: string = "default";

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -17,7 +17,7 @@
 // 
 
 
-export { EntryGranularity, HeaderTemplate, InlineTemplate, InputDetailsTimeFormat, JournalPageType, NavigationMode, ScopeDefinitionLite, ScopedTemplate } from './config';
+export { EntryGranularity, HeaderTemplate, InlineTemplate, InputDetailsTimeFormat, JournalPageType, NavigationMode, ScopeDefinitionLite, ScopedTemplate, SCOPE_DEFAULT } from './config';
 export { InlineString } from './inline';
 export { Input, NoteInput, SelectedInput } from './input';
 export { ScopeDirectory, TemplateInfo } from './templates';

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -172,12 +172,19 @@ export class Input {
         }
         let date = new Date();
         date.setDate(date.getDate() + this.offset);
-        return date; 
-
+        return date;
     }
 
-
-    
+    public extractScopeAndTags(availableScopes: string[]): void {
+        this._text.match(/#\w+(?:\s|$)/g)?.forEach(match => {
+            const tag = match.trim();
+            this._tags.push(tag);
+            this._text = this._text.replace(match, " ");
+            const scopeName = tag.substring(1);
+            const matched = availableScopes.find(name => name === scopeName);
+            if (matched) { this._scope = matched; }
+        });
+    }
 }
 
 export class NoteInput extends Input {
@@ -190,17 +197,6 @@ export class NoteInput extends Input {
 
     public get path() { return this._path; }
     public set path(path: string) { this._path = path; }
-
-    public extractScopeAndTags(availableScopes: string[]): void {
-        this._text.match(/#\w+(?:\s|$)/g)?.forEach(match => {
-            const tag = match.trim();
-            this._tags.push(tag);
-            this._text = this._text.replace(match, " ");
-            const scopeName = tag.substring(1);
-            const matched = availableScopes.find(name => name === scopeName);
-            if (matched) { this._scope = matched; }
-        });
-    }
 }
 
 export class SelectedInput extends Input {

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -20,19 +20,20 @@
 'use strict';
 
 import { isNullOrUndefined } from "../util/util";
+import { SCOPE_DEFAULT } from "./config";
 
 export class Input {
 
 
-    
-    private _offset: number; 
-    private _flags: string = ""; 
-    private _text: string = ""; 
-    private _scope: string = ""; 
-    private _week: number; 
+
+    private _offset: number;
+    private _flags: string = "";
+    protected _text: string = "";
+    protected _scope: string = SCOPE_DEFAULT;
+    private _week: number;
     private _date: Date | undefined;
-    
-    private _tags: string[] = []; 
+
+    protected _tags: string[] = [];
 
  
 
@@ -181,15 +182,25 @@ export class Input {
 
 export class NoteInput extends Input {
 
-    private _path: string = ""; 
+    private _path: string = "";
 
     constructor() {
-        super(0); 
+        super(0);
     }
 
-    public get path() {return this._path;}
-    public set path( path: string ) {this._path = path;}
-    
+    public get path() { return this._path; }
+    public set path(path: string) { this._path = path; }
+
+    public extractScopeAndTags(availableScopes: string[]): void {
+        this._text.match(/#\w+(?:\s|$)/g)?.forEach(match => {
+            const tag = match.trim();
+            this._tags.push(tag);
+            this._text = this._text.replace(match, " ");
+            const scopeName = tag.substring(1);
+            const matched = availableScopes.find(name => name === scopeName);
+            if (matched) { this._scope = matched; }
+        });
+    }
 }
 
 export class SelectedInput extends Input {

--- a/src/test/suite/input.test.ts
+++ b/src/test/suite/input.test.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
+import { SCOPE_DEFAULT } from '../../model/config';
 
 suite('Open Journal Entries', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -216,6 +217,56 @@ suite('Issue #170 — weekday/month/shortcut prefix collisions', () => {
 	test("'week 15' still resolves to week 15", async () => {
 		const input = await parse("week 15");
 		assert.strictEqual(input.week, 15, "expected week 15, got " + input.week);
+	});
+
+});
+
+suite('NoteInput.extractScopeAndTags (#210)', () => {
+
+	test("noTags: text without tags stays unchanged, scope defaults", () => {
+		const input = new J.Model.NoteInput();
+		input.text = "my note";
+		input.extractScopeAndTags([]);
+		assert.strictEqual(input.scope, SCOPE_DEFAULT);
+		assert.deepStrictEqual(input.tags, []);
+		assert.strictEqual(input.text, "my note");
+	});
+
+	test("namedScopeMatch: matching tag sets scope, strips from text", () => {
+		const input = new J.Model.NoteInput();
+		input.text = "my note #work ";
+		input.extractScopeAndTags(["work"]);
+		assert.strictEqual(input.scope, "work");
+		assert.deepStrictEqual(input.tags, ["#work"]);
+		assert.ok(!input.text.includes("#work"), "tag should be stripped from text");
+	});
+
+	test("noScopeMatch: unknown tag collected but scope stays default", () => {
+		const input = new J.Model.NoteInput();
+		input.text = "my note #unknown ";
+		input.extractScopeAndTags(["work"]);
+		assert.strictEqual(input.scope, SCOPE_DEFAULT);
+		assert.deepStrictEqual(input.tags, ["#unknown"]);
+		assert.ok(!input.text.includes("#unknown"), "tag should be stripped from text");
+	});
+
+	test("multipleTags: both tags collected, first matching scope wins", () => {
+		const input = new J.Model.NoteInput();
+		input.text = "note #work #meeting ";
+		input.extractScopeAndTags(["work"]);
+		assert.strictEqual(input.scope, "work");
+		assert.deepStrictEqual(input.tags, ["#work", "#meeting"]);
+		assert.ok(!input.text.includes("#work"), "#work should be stripped");
+		assert.ok(!input.text.includes("#meeting"), "#meeting should be stripped");
+	});
+
+	test("tagAtEndOfString: tag without trailing space is matched (regex fix)", () => {
+		const input = new J.Model.NoteInput();
+		input.text = "note #work";
+		input.extractScopeAndTags(["work"]);
+		assert.strictEqual(input.scope, "work");
+		assert.deepStrictEqual(input.tags, ["#work"]);
+		assert.ok(!input.text.includes("#work"), "tag should be stripped from text");
 	});
 
 });

--- a/src/test/suite/read-templates.test.ts
+++ b/src/test/suite/read-templates.test.ts
@@ -83,7 +83,7 @@ suite('Read templates from configuration', () => {
 
         // create a new note
         const privInput = await ctrl.parser.parseInput("#priv a note created in private scop");
-        let privNotes = await new J.Features.LoadNotes(privInput, ctrl);
+        let privNotes = await new J.Features.LoadNotes(privInput as J.Model.NoteInput, ctrl);
         let privDoc: vscode.TextDocument = await privNotes.load();
         privDoc = await ctrl.ui.saveDocument(privDoc);
         const privUri = privDoc.uri;
@@ -91,7 +91,7 @@ suite('Read templates from configuration', () => {
 
 
         const workInput = await ctrl.parser.parseInput("#work a note created in work scope");
-        let workDoc: vscode.TextDocument = await new J.Features.LoadNotes(workInput, ctrl).load();
+        let workDoc: vscode.TextDocument = await new J.Features.LoadNotes(workInput as J.Model.NoteInput, ctrl).load();
         workDoc = await ctrl.ui.saveDocument(workDoc);
         const uriWork = workDoc.uri;
 

--- a/src/vscode/conf.ts
+++ b/src/vscode/conf.ts
@@ -22,10 +22,10 @@ import * as os from 'os';
 import * as Path from 'path';
 import { Util } from '..';
 import { isNotNullOrUndefined, isNullOrUndefined } from '../util';
-import { HeaderTemplate, InlineTemplate, ScopedTemplate } from '../model';
+import { HeaderTemplate, InlineTemplate, ScopedTemplate, SCOPE_DEFAULT } from '../model';
 import { replaceDateFormats, replaceVariableValue } from '../util';
 
-export const SCOPE_DEFAULT: string = "default";
+export { SCOPE_DEFAULT };
 
 export type WeeklySyncConfig = {
     enabled: boolean;


### PR DESCRIPTION
## Summary

- Moves `SCOPE_DEFAULT` from `src/vscode/conf.ts` → `src/model/config.ts` (re-exported for backward compat)
- Changes `Input._text/_scope/_tags` from `private` → `protected`; `_scope` initializes to `SCOPE_DEFAULT` at field declaration (no more empty-string default)
- Adds `NoteInput.extractScopeAndTags(availableScopes: string[]): void` with hardened regex `/#\w+(?:\s|$)/g` (handles end-of-string tags)
- `Parser.resolveNotePathForInput` delegates to `extractScopeAndTags`; removes inline tag loop and now-unused imports
- `LoadNotes` constructor narrowed to `NoteInput`; callers updated with type assertions
- 5 unit tests added (no vscode API needed; pure sync)

Closes #210

**Spec:** [docs/specs/2026-05-17-210-rich-domain-models.md](../blob/develop/docs/specs/2026-05-17-210-rich-domain-models.md)
**Plan:** [docs/plans/2026-05-17-210-rich-domain-models.md](../blob/develop/docs/plans/2026-05-17-210-rich-domain-models.md)

## Test plan

- [ ] `npm run compile` — clean build
- [ ] `npx tsc --noEmit` — no type errors
- [ ] Run extension tests: `NoteInput.extractScopeAndTags` suite (5 scenarios including end-of-string regex coverage)
- [ ] Manual smoke test: open note with `#scope` tag, verify scope routing and tag stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)