### PR TITLE
refactor(paths): decouple inferType from raw positional args (#199)

### DIFF
--- a/src/features/entries/scan-entries.ts
+++ b/src/features/entries/scan-entries.ts
@@ -65,7 +65,7 @@ export class ScanEntries {
 
             await this.walkDir(directory.path, thresholdInMs, (entries: J.Model.FileEntry[]) => {
                 entries.forEach(entry => {
-                    entry.type = J.Journal.inferType(Path.parse(entry.path), this.config.getFileExtension());
+                    entry.type = J.Journal.inferType(Path.parse(entry.path), { extension: this.config.getFileExtension() });
                     entry.scope = directory.scope;
                     this.cache.set(entry.path, entry);
                 });
@@ -137,7 +137,7 @@ export class ScanEntries {
 
         await this.walkDir(directory.path, thresholdInMs, (entries: J.Model.FileEntry[]) => {
             entries.forEach(fe => {
-                fe.type = J.Journal.inferType(Path.parse(fe.path), this.config.getFileExtension());
+                fe.type = J.Journal.inferType(Path.parse(fe.path), { extension: this.config.getFileExtension() });
                 fe.scope = directory.scope;
                 if (!this.cache.has(fe.path)) {
                     this.cache.set(fe.path, fe);

--- a/src/journal/paths.ts
+++ b/src/journal/paths.ts
@@ -168,25 +168,20 @@ export async function checkIfFileIsAccessible(path: string): Promise<void> {
 }
 
 
-/**
- * Tries to infer the file type from the path by matching against the configured patterns
- * @param entry - path to entry
- * @param ext - configured standard extension 
- */
-export function inferType(entry: Path.ParsedPath, extension: string): J.Model.JournalPageType {
+/** Context passed to inferType. All future fields must be optional (?:) to prevent shotgun surgery. */
+export interface InferTypeContext {
+    extension: string;
+}
 
-    if (!entry.ext.endsWith(extension)) {
-        return J.Model.JournalPageType.attachement; // any attachement
-    } else
+export function inferType(entry: Path.ParsedPath, ctx: InferTypeContext): J.Model.JournalPageType {
 
-        // this is getting out of hand if we need to infer it by scanning the patterns from the settings.
-        // We keep it simple: if the filename contains only digits and special chars, we assume it 
-        // is a journal entry. Everything else is a journal note. 
-        if (entry.name.match(/^[\d\-_]+$/)) {
-            return J.Model.JournalPageType.entry; // any entry
-        } else {
-            return J.Model.JournalPageType.note; // anything else is a note
-        }
+    if (!entry.ext.endsWith(ctx.extension)) {
+        return J.Model.JournalPageType.attachement;
+    } else if (entry.name.match(/^[\d\-_]+$/)) {
+        return J.Model.JournalPageType.entry;
+    } else {
+        return J.Model.JournalPageType.note;
+    }
 
 
 }

--- a/src/journal/paths.ts
+++ b/src/journal/paths.ts
@@ -182,7 +182,7 @@ export function inferType(entry: Path.ParsedPath, extension: string): J.Model.Jo
         // this is getting out of hand if we need to infer it by scanning the patterns from the settings.
         // We keep it simple: if the filename contains only digits and special chars, we assume it 
         // is a journal entry. Everything else is a journal note. 
-        if (entry.name.match(/^[\d|\-|_]+$/gm)) {
+        if (entry.name.match(/^[\d\-_]+$/)) {
             return J.Model.JournalPageType.entry; // any entry
         } else {
             return J.Model.JournalPageType.note; // anything else is a note

--- a/src/test/suite/infer-type.test.ts
+++ b/src/test/suite/infer-type.test.ts
@@ -1,55 +1,55 @@
 import * as assert from 'assert';
 import * as Path from 'path';
-import { inferType } from '../../journal/paths';
+import { inferType, InferTypeContext } from '../../journal/paths';
 import { JournalPageType } from '../../model/config';
 
 suite('inferType — classification', () => {
-    const EXT = '.md';
+    const ctx: InferTypeContext = { extension: '.md' };
 
     suite('attachment', () => {
         test('extension mismatch → attachement', () => {
             const entry = Path.parse('/base/2026/05/2026-05-18.txt');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.attachement);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.attachement);
         });
 
         test('no extension → attachement', () => {
             const entry = Path.parse('/base/2026/05/2026-05-18');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.attachement);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.attachement);
         });
     });
 
     suite('entry', () => {
         test('digits-only name → entry', () => {
             const entry = Path.parse('/base/2026/05/20260518.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.entry);
         });
 
         test('digits with hyphens → entry', () => {
             const entry = Path.parse('/base/2026/05/2026-05-18.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.entry);
         });
 
         test('digits with underscores → entry', () => {
             const entry = Path.parse('/base/2026/05/2026_05_18.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.entry);
         });
 
         test('pipe-separated name → note (pipe not a separator)', () => {
             // Pipe was previously a literal in the character class; now correctly excluded.
             const entry = Path.parse('/base/2026/05/2026|05|18.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.note);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.note);
         });
     });
 
     suite('note', () => {
         test('alphanumeric name → note', () => {
             const entry = Path.parse('/base/2026/05/my-note.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.note);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.note);
         });
 
         test('name with letters and digits → note', () => {
             const entry = Path.parse('/base/2026/05/meeting2026.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.note);
+            assert.strictEqual(inferType(entry, ctx), JournalPageType.note);
         });
     });
 });

--- a/src/test/suite/infer-type.test.ts
+++ b/src/test/suite/infer-type.test.ts
@@ -34,13 +34,10 @@ suite('inferType — classification', () => {
             assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
         });
 
-        // Pre-fix quirk: pipe (`|`) is a literal char in the character class,
-        // so pipe-separated names currently classify as entry on non-Windows.
-        // This test documents current behavior; it will be updated in Step 0b
-        // when the regex is corrected.
-        test('pipe-separated name → entry (pre-fix quirk)', () => {
+        test('pipe-separated name → note (pipe not a separator)', () => {
+            // Pipe was previously a literal in the character class; now correctly excluded.
             const entry = Path.parse('/base/2026/05/2026|05|18.md');
-            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.note);
         });
     });
 

--- a/src/test/suite/infer-type.test.ts
+++ b/src/test/suite/infer-type.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as Path from 'path';
+import { inferType } from '../../journal/paths';
+import { JournalPageType } from '../../model/config';
+
+suite('inferType — classification', () => {
+    const EXT = '.md';
+
+    suite('attachment', () => {
+        test('extension mismatch → attachement', () => {
+            const entry = Path.parse('/base/2026/05/2026-05-18.txt');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.attachement);
+        });
+
+        test('no extension → attachement', () => {
+            const entry = Path.parse('/base/2026/05/2026-05-18');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.attachement);
+        });
+    });
+
+    suite('entry', () => {
+        test('digits-only name → entry', () => {
+            const entry = Path.parse('/base/2026/05/20260518.md');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+        });
+
+        test('digits with hyphens → entry', () => {
+            const entry = Path.parse('/base/2026/05/2026-05-18.md');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+        });
+
+        test('digits with underscores → entry', () => {
+            const entry = Path.parse('/base/2026/05/2026_05_18.md');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+        });
+
+        // Pre-fix quirk: pipe (`|`) is a literal char in the character class,
+        // so pipe-separated names currently classify as entry on non-Windows.
+        // This test documents current behavior; it will be updated in Step 0b
+        // when the regex is corrected.
+        test('pipe-separated name → entry (pre-fix quirk)', () => {
+            const entry = Path.parse('/base/2026/05/2026|05|18.md');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.entry);
+        });
+    });
+
+    suite('note', () => {
+        test('alphanumeric name → note', () => {
+            const entry = Path.parse('/base/2026/05/my-note.md');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.note);
+        });
+
+        test('name with letters and digits → note', () => {
+            const entry = Path.parse('/base/2026/05/meeting2026.md');
+            assert.strictEqual(inferType(entry, EXT), JournalPageType.note);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add `InferTypeContext { extension: string }` interface colocated in `src/journal/paths.ts` — all future fields must be optional (`?:`) to prevent shotgun surgery on additions
- Change `inferType(entry, extension: string)` → `inferType(entry, ctx: InferTypeContext)`; update both call sites in `scan-entries.ts`
- Fix pre-existing regex bug: remove pipe literal from `[\d|\-|_]` (valid char on macOS/Linux) and drop unnecessary `gm` flags
- Add 8 unit tests in `src/test/suite/infer-type.test.ts` locking down classification behavior before any signature change

## Test Plan

- [x] `npm run compile` — esbuild clean
- [x] `npm run compile-tests` — tsc clean
- [x] `npm test` — 167 passing (8 new)

## Related

Closes #199
Spec: [docs/specs/2026-05-18-199-infer-type-context-object.md](../blob/develop/docs/specs/2026-05-18-199-infer-type-context-object.md)
Plan: [docs/plans/2026-05-18-199-infer-type-context-object.md](../blob/develop/docs/plans/2026-05-18-199-infer-type-context-object.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)