### PR TITLE
test(config): decouple test suite from global VS Code workspace config (#202)

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -22,6 +22,6 @@ export { InlineString } from './inline';
 export { Input, NoteInput, SelectedInput } from './input';
 export { ScopeDirectory, TemplateInfo } from './templates';
 export { FileEntry } from './files';
-export { ILogger, IConfiguration, IParser, IWriter, IReader, IInject, IDialogues, IFileSystem, DocumentOpener, JournalController } from './interfaces';
+export { ILogger, IConfiguration, IParser, IWriter, IReader, IInject, IDialogues, IFileSystem, DocumentOpener, JournalController, IWorkspaceConfigReader } from './interfaces';
 export { JFileType, JFileStat } from './fs';
 

--- a/src/model/interfaces.ts
+++ b/src/model/interfaces.ts
@@ -97,3 +97,8 @@ export interface JournalController {
     ui: IDialogues;
     fs: IFileSystem;
 }
+
+export interface IWorkspaceConfigReader {
+    get<T>(section: string): T | undefined;
+    get<T>(section: string, defaultValue: T): T;
+}

--- a/src/test/fake-workspace-config.ts
+++ b/src/test/fake-workspace-config.ts
@@ -1,0 +1,11 @@
+import { IWorkspaceConfigReader } from '../model';
+
+export class FakeWorkspaceConfig implements IWorkspaceConfigReader {
+    constructor(private readonly settings: Record<string, unknown> = {}) {}
+
+    get<T>(section: string, defaultValue?: T): T | undefined {
+        return (section in this.settings
+            ? this.settings[section]
+            : defaultValue) as T | undefined;
+    }
+}

--- a/src/test/suite/commands-entry.test.ts
+++ b/src/test/suite/commands-entry.test.ts
@@ -10,12 +10,10 @@ import { ShowEntryForYesterdayCommand } from '../../commands/show-entry-for-yest
 import { createMockCtrl, tick } from './command-test-helpers';
 import { TestLogger } from '../test-logger';
 import { fileExists } from '../../util/fs-exists';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-    const refreshed = vscode.workspace.getConfiguration('journal');
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -206,23 +204,18 @@ suite('Command suites - entry commands', () => {
 suite('Entry commands — real filesystem', function () {
     this.slow(8000);
 
-    let originalBase: string | undefined;
     let tmpBase: string;
     let ctrl: J.Util.Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        originalBase = config.get<string>('base');
         tmpBase = path.join(os.tmpdir(), `entry-real-${Date.now()}`);
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-        ({ ctrl, logger } = await buildCtrl(tmpBase));
+        ({ ctrl, logger } = buildCtrl(tmpBase));
         (ctrl.ui as any).showDocument = async (_doc: vscode.TextDocument) => undefined;
     });
 
     teardown(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
     });

--- a/src/test/suite/commands-inject.test.ts
+++ b/src/test/suite/commands-inject.test.ts
@@ -4,12 +4,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-    const refreshed = vscode.workspace.getConfiguration('journal');
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -18,22 +16,17 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
 suite('Inject — memo and task insertion', function () {
     this.slow(5000);
 
-    let originalBase: string | undefined;
     let tmpBase: string;
     let ctrl: J.Util.Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        originalBase = config.get<string>('base');
         tmpBase = path.join(os.tmpdir(), `inject-base-${Date.now()}`);
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-        ({ ctrl, logger } = await buildCtrl(tmpBase));
+        ({ ctrl, logger } = buildCtrl(tmpBase));
     });
 
     teardown(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
     });

--- a/src/test/suite/commands-note.test.ts
+++ b/src/test/suite/commands-note.test.ts
@@ -6,12 +6,10 @@ import * as J from '../..';
 import { ShowNoteCommand } from '../../commands/show-note';
 import { TestLogger } from '../test-logger';
 import { fileExists } from '../../util/fs-exists';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-    const refreshed = vscode.workspace.getConfiguration('journal');
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -20,22 +18,17 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
 suite('ShowNoteCommand — note creation', function () {
     this.slow(5000);
 
-    let originalBase: string | undefined;
     let tmpBase: string;
     let ctrl: J.Util.Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        originalBase = config.get<string>('base');
         tmpBase = path.join(os.tmpdir(), `note-base-${Date.now()}`);
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-        ({ ctrl, logger } = await buildCtrl(tmpBase));
+        ({ ctrl, logger } = buildCtrl(tmpBase));
     });
 
     teardown(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
     });

--- a/src/test/suite/commands-prev-next.test.ts
+++ b/src/test/suite/commands-prev-next.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 import {
     addDays,
     daysBetween,
@@ -27,18 +28,8 @@ async function seedEntry(base: string, year: number, month: number, day: number,
     return file.fsPath;
 }
 
-async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-    // On CI the config write is async; poll until the value is visible.
-    const deadline = Date.now() + 3000;
-    let refreshed: vscode.WorkspaceConfiguration;
-    do {
-        refreshed = vscode.workspace.getConfiguration('journal');
-        if (refreshed.get<string>('base') === tmpBase) { break; }
-        await new Promise<void>(r => setTimeout(r, 50));
-    } while (Date.now() < deadline);
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(tmpBase: string, extra: Record<string, unknown> = {}): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase, ...extra }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -72,27 +63,16 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
     });
 
     suite('helper layer with seeded base', () => {
-        let originalBase: string | undefined;
-        let originalMode: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
-            originalMode = config.get<string>('navigation.mode');
-
             tmpBase = path.join(os.tmpdir(), `issue144-base-${Date.now()}`);
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-            await config.update('navigation.mode', 'existing', vscode.ConfigurationTarget.Workspace);
-
-            ({ ctrl } = await buildCtrl(tmpBase));
+            ({ ctrl } = buildCtrl(tmpBase, { 'navigation.mode': 'existing' }));
         });
 
         teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
-            await config.update('navigation.mode', originalMode, vscode.ConfigurationTarget.Workspace);
             try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
         });
 
@@ -201,23 +181,16 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
     });
 
     suite('command layer', () => {
-        let originalBase: string | undefined;
-        let originalMode: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
         let infoMessages: string[];
         let originalShowInfo: typeof vscode.window.showInformationMessage;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
-            originalMode = config.get<string>('navigation.mode');
-
             tmpBase = path.join(os.tmpdir(), `issue144-cmd-${Date.now()}`);
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-            await config.update('navigation.mode', 'existing', vscode.ConfigurationTarget.Workspace);
 
-            ({ ctrl } = await buildCtrl(tmpBase));
+            ({ ctrl } = buildCtrl(tmpBase, { 'navigation.mode': 'existing' }));
 
             infoMessages = [];
             originalShowInfo = vscode.window.showInformationMessage;
@@ -229,9 +202,6 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
 
         teardown(async () => {
             (vscode.window as any).showInformationMessage = originalShowInfo;
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
-            await config.update('navigation.mode', originalMode, vscode.ConfigurationTarget.Workspace);
             try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
             await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         });
@@ -267,9 +237,6 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
         });
 
         test('OpenNextEntryCommand in calendar mode creates the next-day entry', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('navigation.mode', 'calendar', vscode.ConfigurationTarget.Workspace);
-
             // Use yesterday as anchor so next = today; offset is -1 (no large DST-sensitive arithmetic).
             const yesterday = new Date();
             yesterday.setDate(yesterday.getDate() - 1);
@@ -282,7 +249,9 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
             const anchorDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(anchorPath));
             await vscode.window.showTextDocument(anchorDoc);
 
-            const cmdInstance = new (OpenNextEntryCommand as any)(ctrl);
+            const { ctrl: calendarCtrl } = buildCtrl(tmpBase, { 'navigation.mode': 'calendar' });
+            calendarCtrl.initServices(ctrl.logger);
+            const cmdInstance = new (OpenNextEntryCommand as any)(calendarCtrl);
             await cmdInstance.run();
 
             const today = new Date();
@@ -304,35 +273,20 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
     suite('scoped navigation (#144 scope isolation)', function () {
         this.slow(8000);
 
-        let originalBase: string | undefined;
-        let originalMode: string | undefined;
-        let originalScopes: unknown;
         let tmpBase: string;
         let workBase: string;
         let ctrl: J.Util.Ctrl;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
-            originalMode = config.get<string>('navigation.mode');
-            originalScopes = config.get('scopes');
-
             tmpBase = path.join(os.tmpdir(), `issue144-scoped-${Date.now()}`);
             workBase = path.join(tmpBase, 'work');
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(workBase));
 
-            await config.update('scopes', [{ name: 'work', base: workBase }], vscode.ConfigurationTarget.Workspace);
-            await config.update('navigation.mode', 'existing', vscode.ConfigurationTarget.Workspace);
-
-            ({ ctrl } = await buildCtrl(tmpBase));
+            ({ ctrl } = buildCtrl(tmpBase, { 'navigation.mode': 'existing', scopes: [{ name: 'work', base: workBase }] }));
         });
 
         teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
-            await config.update('navigation.mode', originalMode, vscode.ConfigurationTarget.Workspace);
-            await config.update('scopes', originalScopes, vscode.ConfigurationTarget.Workspace);
             try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
             await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         });
@@ -375,21 +329,16 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
     });
 
     suite('getAdjacentWeekInput (#200)', () => {
-        let originalBase: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
             tmpBase = path.join(os.tmpdir(), `issue200-week-${Date.now()}`);
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-            ({ ctrl } = await buildCtrl(tmpBase));
+            ({ ctrl } = buildCtrl(tmpBase));
         });
 
         teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
             try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
             await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         });

--- a/src/test/suite/commands-weekly.test.ts
+++ b/src/test/suite/commands-weekly.test.ts
@@ -5,12 +5,10 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
 import { fileExists } from '../../util/fs-exists';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-    const refreshed = vscode.workspace.getConfiguration('journal');
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -19,22 +17,17 @@ async function buildCtrl(tmpBase: string): Promise<{ ctrl: J.Util.Ctrl; logger: 
 suite('Weekly entry creation', function () {
     this.slow(5000);
 
-    let originalBase: string | undefined;
     let tmpBase: string;
     let ctrl: J.Util.Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        originalBase = config.get<string>('base');
         tmpBase = path.join(os.tmpdir(), `weekly-base-${Date.now()}`);
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-        ({ ctrl, logger } = await buildCtrl(tmpBase));
+        ({ ctrl, logger } = buildCtrl(tmpBase));
     });
 
     teardown(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
     });

--- a/src/test/suite/input.test.ts
+++ b/src/test/suite/input.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
 import { SCOPE_DEFAULT } from '../../model/config';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Open Journal Entries', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -18,8 +19,7 @@ suite('Open Journal Entries', () => {
 	})
 		;
 	test("Input '+1'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -31,8 +31,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input '2021-05-12'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -43,8 +42,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input '05-12'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -55,8 +53,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input '12'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -67,8 +64,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input 'next monday'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -79,8 +75,7 @@ suite('Open Journal Entries', () => {
 	});
 
 	test("Input 'next tue'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -90,8 +85,7 @@ suite('Open Journal Entries', () => {
 	});
 
 	test("Input 'last wed'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -102,8 +96,7 @@ suite('Open Journal Entries', () => {
 
 
 	test("Input 'task +1 do this'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -116,8 +109,7 @@ suite('Open Journal Entries', () => {
 	});
 
 	test("Input 'task next wed do this'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -136,8 +128,7 @@ suite('Open Journal Entries', () => {
 suite('Issue #170 — weekday/month/shortcut prefix collisions', () => {
 
 	async function parse(text: string): Promise<J.Model.Input> {
-		const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		const ctrl = new J.Util.Ctrl(config);
+		const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 		return ctrl.parser.parseInput(text);
 	}

--- a/src/test/suite/issue-168-entry-granularity.test.ts
+++ b/src/test/suite/issue-168-entry-granularity.test.ts
@@ -5,16 +5,11 @@ import * as vscode from 'vscode';
 import moment = require('moment');
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 import { MatchInput } from '../../journal/match-input';
 
-async function setBase(tmpBase: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-}
-
-async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const refreshed = vscode.workspace.getConfiguration('journal');
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(settings: Record<string, unknown>): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig(settings));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -23,39 +18,18 @@ async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
 suite('Issue #168 — Entry granularity', () => {
 
     suite('Configuration.getEntryGranularity', () => {
-        let originalGranularity: string | undefined;
-
-        setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalGranularity = config.get<string>('entryGranularity');
-        });
-
-        teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('entryGranularity', originalGranularity, vscode.ConfigurationTarget.Workspace);
-        });
-
-        test('defaults to "daily" when setting is unset', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('entryGranularity', undefined, vscode.ConfigurationTarget.Workspace);
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(refreshed);
+        test('defaults to "daily" when setting is unset', () => {
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
             assert.strictEqual(conf.getEntryGranularity(), 'daily');
         });
 
-        test('returns "weekly" when setting is "weekly"', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('entryGranularity', 'weekly', vscode.ConfigurationTarget.Workspace);
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(refreshed);
+        test('returns "weekly" when setting is "weekly"', () => {
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ entryGranularity: 'weekly' }));
             assert.strictEqual(conf.getEntryGranularity(), 'weekly');
         });
 
-        test('returns "daily" for any unknown value (defensive)', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('entryGranularity', 'monthly', vscode.ConfigurationTarget.Workspace);
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(refreshed);
+        test('returns "daily" for any unknown value (defensive)', () => {
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ entryGranularity: 'monthly' }));
             assert.strictEqual(conf.getEntryGranularity(), 'daily');
         });
     });
@@ -123,8 +97,7 @@ suite('Issue #168 — Entry granularity', () => {
 
     suite('Default weekly template includes section anchors', () => {
         test('getWeeklyTemplate renders ## Tasks and ## Notes sections', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(config);
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
             const tpl = await conf.getWeeklyTemplate(7);
             assert.ok(tpl.value, 'template value should be set');
             assert.ok(tpl.value!.includes('# Week 7'), `expected '# Week 7' in: ${tpl.value}`);
@@ -134,24 +107,14 @@ suite('Issue #168 — Entry granularity', () => {
     });
 
     suite('Configuration.getResolvedWeeklyNotesPath', () => {
-        let originalBase: string | undefined;
         let tmpBase: string;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
             tmpBase = path.join(os.tmpdir(), `issue168-${Date.now()}`);
-            await setBase(tmpBase);
-        });
-
-        teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         });
 
         test('resolves the default weekly notes path with year and week substituted', async () => {
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(refreshed);
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ base: tmpBase }));
 
             const resolved = await conf.getResolvedWeeklyNotesPath(20, 2026);
             assert.ok(resolved.value, 'resolved value should be set');
@@ -164,8 +127,7 @@ suite('Issue #168 — Entry granularity', () => {
         });
 
         test('weekly notes file pattern substitutes input', async () => {
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(refreshed);
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ base: tmpBase }));
 
             const filePattern = await conf.getWeeklyNotesFilePattern(20, 2026, 'My_Note');
             assert.ok(filePattern.value, 'file pattern value should be set');
@@ -177,29 +139,15 @@ suite('Issue #168 — Entry granularity', () => {
     });
 
     suite('Parser.resolveNotePathForInput honors granularity', () => {
-        let originalBase: string | undefined;
-        let originalGranularity: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
-            originalGranularity = config.get<string>('entryGranularity');
             tmpBase = path.join(os.tmpdir(), `issue168-notes-${Date.now()}`);
-            await setBase(tmpBase);
-        });
-
-        teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
-            await config.update('entryGranularity', originalGranularity, vscode.ConfigurationTarget.Workspace);
         });
 
         test('granularity=daily: notes path uses day-keyed pattern (regression)', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('entryGranularity', 'daily', vscode.ConfigurationTarget.Workspace);
-            ({ ctrl } = await buildCtrl());
+            ({ ctrl } = buildCtrl({ base: tmpBase, entryGranularity: 'daily' }));
 
             const input = new J.Model.Input(0);
             input.text = 'My_Note';
@@ -213,9 +161,7 @@ suite('Issue #168 — Entry granularity', () => {
         });
 
         test('granularity=weekly: notes path uses week-keyed pattern', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('entryGranularity', 'weekly', vscode.ConfigurationTarget.Workspace);
-            ({ ctrl } = await buildCtrl());
+            ({ ctrl } = buildCtrl({ base: tmpBase, entryGranularity: 'weekly' }));
 
             const input = new J.Model.Input(0);
             input.text = 'My_Note';

--- a/src/test/suite/issue-185-weekly-sync.test.ts
+++ b/src/test/suite/issue-185-weekly-sync.test.ts
@@ -8,15 +8,10 @@ import { SyncDailyLinks } from '../../features/sync/sync-daily-links';
 import { getWeekFromURIAndConfig } from '../../journal/paths';
 import { getDatesOfISOWeek } from '../../util/dates';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-async function setBase(tmpBase: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration('journal');
-    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
-}
-
-async function buildCtrl(): Promise<{ ctrl: J.Util.Ctrl; logger: TestLogger }> {
-    const refreshed = vscode.workspace.getConfiguration('journal');
-    const ctrl = new J.Util.Ctrl(refreshed);
+function buildCtrl(settings: Record<string, unknown>): { ctrl: J.Util.Ctrl; logger: TestLogger } {
+    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig(settings));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -51,21 +46,12 @@ suite('Issue #185 — Weekly daily-link sync', () => {
     });
 
     suite('URI helper — getWeekFromURIAndConfig', () => {
-        let originalBase: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
             tmpBase = path.join(os.tmpdir(), `issue185-uri-${Date.now()}`);
-            await setBase(tmpBase);
-            ({ ctrl } = await buildCtrl());
-        });
-
-        teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+            ({ ctrl } = buildCtrl({ base: tmpBase }));
         });
 
         test('recognizes default weekly path and extracts week + year', async () => {
@@ -96,8 +82,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('Configuration.getWeeklySyncConfig', () => {
         test('returns defaults when setting is unset', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(config);
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
             const syncCfg = conf.getWeeklySyncConfig();
             assert.strictEqual(syncCfg.enabled, true);
             assert.strictEqual(syncCfg.anchor, '## Daily Entries');
@@ -107,27 +92,18 @@ suite('Issue #185 — Weekly daily-link sync', () => {
     });
 
     suite('SyncDailyLinks — rendering (unit)', () => {
-        let originalBase: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
         let weeklyUri: vscode.Uri;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
             tmpBase = path.join(os.tmpdir(), `issue185-render-${Date.now()}`);
-            await setBase(tmpBase);
-            ({ ctrl } = await buildCtrl());
+            ({ ctrl } = buildCtrl({ base: tmpBase }));
 
             // Create the weekly file placeholder (content irrelevant for rendering unit test).
             weeklyUri = vscode.Uri.file(path.join(tmpBase, '2026', 'week_20.md'));
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026')));
             await writeFile(weeklyUri, '# Week 20\n\n## Daily Entries\n\n');
-        });
-
-        teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         });
 
         test('renderBlock produces one line per URI in ascending order', async () => {
@@ -161,28 +137,20 @@ suite('Issue #185 — Weekly daily-link sync', () => {
             await writeFile(friUri, '');
 
             // Override weeklySync to descending.
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('weeklySync', { enabled: true, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'descending' }, vscode.ConfigurationTarget.Workspace);
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const descCtrl = new J.Util.Ctrl(refreshed);
+            const { ctrl: descCtrl } = buildCtrl({ base: tmpBase, weeklySync: { enabled: true, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'descending' } });
             descCtrl.initServices(ctrl.logger);
 
-            try {
-                const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
-                const syncer = new SyncDailyLinks(descCtrl);
-                const block = await syncer.renderBlock(weeklyDoc, [monUri, friUri]);
-                const lines = block.split('\n').filter(l => l.length > 0);
-                // Descending → Friday first.
-                assert.ok(lines[0].includes('05/15.md'), `first line should be Friday: ${lines[0]}`);
-                assert.ok(lines[1].includes('05/11.md'), `second line should be Monday: ${lines[1]}`);
-            } finally {
-                await config.update('weeklySync', undefined, vscode.ConfigurationTarget.Workspace);
-            }
+            const weeklyDoc = await vscode.workspace.openTextDocument(weeklyUri);
+            const syncer = new SyncDailyLinks(descCtrl);
+            const block = await syncer.renderBlock(weeklyDoc, [monUri, friUri]);
+            const lines = block.split('\n').filter(l => l.length > 0);
+            // Descending → Friday first.
+            assert.ok(lines[0].includes('05/15.md'), `first line should be Friday: ${lines[0]}`);
+            assert.ok(lines[1].includes('05/11.md'), `second line should be Monday: ${lines[1]}`);
         });
     });
 
     suite('SyncDailyLinks — integration', () => {
-        let originalBase: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
         let logger: TestLogger;
@@ -190,22 +158,14 @@ suite('Issue #185 — Weekly daily-link sync', () => {
         const weeklyContent = '# Week 20\n\n## Daily Entries\n\n## Notes\n\n';
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
             tmpBase = path.join(os.tmpdir(), `issue185-integ-${Date.now()}`);
-            await setBase(tmpBase);
-            ({ ctrl, logger } = await buildCtrl());
+            ({ ctrl, logger } = buildCtrl({ base: tmpBase }));
 
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026')));
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.join(tmpBase, '2026', '05')));
 
             weeklyUri = vscode.Uri.file(path.join(tmpBase, '2026', 'week_20.md'));
             await writeFile(weeklyUri, weeklyContent);
-        });
-
-        teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         });
 
         test('W8 — golden path: sync injects links for existing daily entries', async () => {
@@ -265,24 +225,17 @@ suite('Issue #185 — Weekly daily-link sync', () => {
         });
 
         test('W11 — enabled=false: sync respects setting', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('weeklySync', { enabled: false, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'ascending' }, vscode.ConfigurationTarget.Workspace);
-            const refreshed = vscode.workspace.getConfiguration('journal');
-            const disabledCtrl = new J.Util.Ctrl(refreshed);
+            const { ctrl: disabledCtrl } = buildCtrl({ base: tmpBase, weeklySync: { enabled: false, anchor: '## Daily Entries', template: '- [${weekday}, ${d:MMMM DD}](${link})', sortOrder: 'ascending' } });
             disabledCtrl.initServices(logger);
 
             const monUri = vscode.Uri.file(path.join(tmpBase, '2026', '05', '11.md'));
             await writeFile(monUri, '');
 
-            try {
-                const doc = await vscode.workspace.openTextDocument(weeklyUri);
-                const syncer = new SyncDailyLinks(disabledCtrl);
-                await syncer.sync(doc, 20, 2026);
-                const result = await readFile(weeklyUri);
-                assert.strictEqual(result, weeklyContent, 'file must be untouched when disabled');
-            } finally {
-                await config.update('weeklySync', undefined, vscode.ConfigurationTarget.Workspace);
-            }
+            const doc = await vscode.workspace.openTextDocument(weeklyUri);
+            const syncer = new SyncDailyLinks(disabledCtrl);
+            await syncer.sync(doc, 20, 2026);
+            const result = await readFile(weeklyUri);
+            assert.strictEqual(result, weeklyContent, 'file must be untouched when disabled');
         });
 
         test('W5 — findDailyEntriesForWeek returns existing URIs only, ascending', async () => {
@@ -303,8 +256,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('Default weekly template includes ## Daily Entries', () => {
         test('W16 — getWeeklyTemplate includes ## Daily Entries anchor', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(config);
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
             const tpl = await conf.getWeeklyTemplate(20);
             assert.ok(tpl.value, 'template value should be set');
             assert.ok(tpl.value!.includes('## Daily Entries'),
@@ -314,8 +266,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('W17 — #168 regression assertions remain green', () => {
         test('existing weekly template test still passes', async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            const conf = new J.VSCode.Configuration(config);
+            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
             const tpl = await conf.getWeeklyTemplate(7);
             assert.ok(tpl.value, 'template value should be set');
             assert.ok(tpl.value!.includes('# Week 7'), `expected '# Week 7' in: ${tpl.value}`);

--- a/src/test/suite/issue-51-remote-create.test.ts
+++ b/src/test/suite/issue-51-remote-create.test.ts
@@ -7,6 +7,7 @@ import { LoadNotes } from '../../features/entries/load-note';
 import { fileExists } from '../../util/fs-exists';
 import { VscodeFileSystem } from '../../vscode/vscode-fs';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
 
@@ -32,22 +33,16 @@ suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
     });
 
     suite('open-before-create antipattern is gone', () => {
-        let originalBase: string | undefined;
         let tmpBase: string;
         let ctrl: J.Util.Ctrl;
         let logger: TestLogger;
         let openCallCount: number;
 
         setup(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            originalBase = config.get<string>('base');
-
             tmpBase = path.join(os.tmpdir(), `issue51-base-${Date.now()}`);
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-            await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
 
-            const refreshedConfig = vscode.workspace.getConfiguration('journal');
-            ctrl = new J.Util.Ctrl(refreshedConfig);
+            ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
             logger = new TestLogger(false);
             ctrl.initServices(logger);
 
@@ -60,8 +55,6 @@ suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
         });
 
         teardown(async () => {
-            const config = vscode.workspace.getConfiguration('journal');
-            await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
             try {
                 await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true });
             } catch { /* ignore */ }

--- a/src/test/suite/notes-sync.test.ts
+++ b/src/test/suite/notes-sync.test.ts
@@ -7,14 +7,14 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import { LoadNotes } from '../../features/entries/load-note';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Test Notes Syncing', () => {
 
     test('Sync notes', async () => {
 
 
-        let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-        let ctrl = new J.Util.Ctrl(config);
+        let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
         ctrl.initServices(new TestLogger(false));
 
         // create a new entry.. remember length

--- a/src/test/suite/phase1-regression.test.ts
+++ b/src/test/suite/phase1-regression.test.ts
@@ -3,13 +3,13 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import { MatchInput } from '../../journal/match-input';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Phase 1 — Regression Tests', () => {
 
     // ── 1.1  Weekly template name mismatch (#167) ─────────────────────────
     test('#167 — getWeeklyTemplate resolves the "weekly" template from config', async () => {
-        const config = vscode.workspace.getConfiguration("journal");
-        const conf = new J.VSCode.Configuration(config);
+        const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
 
         // The default template in package.json is named "weekly"
         const tpl = await conf.getWeeklyTemplate(7);
@@ -94,8 +94,7 @@ suite('Phase 1 — Regression Tests', () => {
     // ── 1.3  Remote workspace support (#94) ───────────────────────────────
     suite('#94 — vscode.workspace.fs file creation', () => {
         test('createSaveLoadTextDocument writes and opens a file via vscode.workspace.fs', async () => {
-            const config = vscode.workspace.getConfiguration("journal");
-            const ctrl = new J.Util.Ctrl(config);
+            const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
             ctrl.initServices(new TestLogger(false));
 
             const tmpDir = require('os').tmpdir();

--- a/src/test/suite/read-templates.test.ts
+++ b/src/test/suite/read-templates.test.ts
@@ -1,53 +1,42 @@
 import * as assert from 'assert';
-import moment = require('moment');
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
-import { suite, before, afterEach, test } from 'mocha';
-import { Ctrl } from '../../util';
-import { fstat } from 'fs';
-import path = require('path');
+import { suite, before, test } from 'mocha';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Read templates from configuration', () => {
     let ctrl: J.Util.Ctrl;
-    let originalScopes: unknown;
 
-    before(async () => {
-        let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-        originalScopes = config.get('scopes');
-        await config.update('scopes', [
-            {
-                name: 'work',
-                patterns: {
-                    notes: {
-                        path: '${base}/scopes/work',
-                        file: '${month}-${day}-${input}.${ext}'
-                    }
+    before(() => {
+        ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({
+            scopes: [
+                {
+                    name: 'work',
+                    patterns: {
+                        notes: {
+                            path: '${base}/scopes/work',
+                            file: '${month}-${day}-${input}.${ext}'
+                        }
+                    },
+                    templates: []
                 },
-                templates: []
-            },
-            {
-                name: 'priv',
-                patterns: {
-                    notes: {
-                        path: '${base}/scopes/private',
-                        file: '${month}-${input}.${ext}'
-                    }
-                },
-                templates: []
-            }
-        ], vscode.ConfigurationTarget.Workspace);
-        config = vscode.workspace.getConfiguration('journal');
-        ctrl = new J.Util.Ctrl(config);
+                {
+                    name: 'priv',
+                    patterns: {
+                        notes: {
+                            path: '${base}/scopes/private',
+                            file: '${month}-${input}.${ext}'
+                        }
+                    },
+                    templates: []
+                }
+            ]
+        }));
         ctrl.initServices(new TestLogger(false));
-    });
-
-    afterEach(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        await config.update('scopes', originalScopes ?? [], vscode.ConfigurationTarget.Workspace);
     });
 
 

--- a/src/test/suite/scan-entries-cache.test.ts
+++ b/src/test/suite/scan-entries-cache.test.ts
@@ -7,6 +7,7 @@ import { ScanEntries } from '../../features/entries/scan-entries';
 import { SCOPE_DEFAULT } from '../../vscode';
 import { JournalPageType, ScopeDirectory } from '../../model';
 import { TestLogger } from '../test-logger';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 async function seedEntry(base: string, year: number, month: number, day: number, content = '# Entry\n'): Promise<void> {
     const yy = String(year).padStart(4, '0');
@@ -19,7 +20,6 @@ async function seedEntry(base: string, year: number, month: number, day: number,
 }
 
 suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
-    let originalBase: string | undefined;
     let tmpBase: string;
     let ctrl: J.Util.Ctrl;
     let scanner: ScanEntries;
@@ -27,19 +27,14 @@ suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
     let originalWalkDir: any;
 
     setup(async () => {
-        const config = vscode.workspace.getConfiguration('journal');
-        originalBase = config.get<string>('base');
-
         tmpBase = path.join(os.tmpdir(), `issue187-base-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-        await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
 
         await seedEntry(tmpBase, 2025, 3, 5);
         await seedEntry(tmpBase, 2025, 3, 8);
         await seedEntry(tmpBase, 2025, 4, 1);
 
-        const refreshed = vscode.workspace.getConfiguration('journal');
-        ctrl = new J.Util.Ctrl(refreshed);
+        ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
         ctrl.initServices(new TestLogger(false));
         scanner = new ScanEntries(ctrl.config, ctrl.logger, ctrl.fs);
 
@@ -55,8 +50,6 @@ suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
 
     teardown(async () => {
         (ScanEntries.prototype as any).walkDir = originalWalkDir;
-        const config = vscode.workspace.getConfiguration('journal');
-        await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
         try { await vscode.workspace.fs.delete(vscode.Uri.file(tmpBase), { recursive: true }); } catch { /* ignore */ }
     });
 

--- a/src/test/suite/week-input.test.ts
+++ b/src/test/suite/week-input.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as J from '../..';
 import { TestLogger } from '../test-logger';
 import { suite, before, test } from 'mocha';
+import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 
 suite('Open Week Entries', () => {
@@ -14,10 +15,8 @@ suite('Open Week Entries', () => {
 	let ctrl: J.Util.Ctrl;
 
 	before(() => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		ctrl = new J.Util.Ctrl(config);
+		ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
-
 	});
 
 	test("Input 'w13'", async () => {
@@ -33,8 +32,7 @@ suite('Open Week Entries', () => {
 
 
 	test("Input 'w'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 		let input = await ctrl.parser.parseInput("w");
@@ -48,8 +46,7 @@ suite('Open Week Entries', () => {
 	});
 
 	test("Input 'next week'", async () => {
-		let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-		let ctrl = new J.Util.Ctrl(config);
+		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 		const thisWeekInput = await ctrl.parser.parseInput("w");

--- a/src/util/controller.ts
+++ b/src/util/controller.ts
@@ -21,7 +21,7 @@
 
 
 import * as vscode from 'vscode';
-import { IFileSystem, ILogger, JournalController } from '../model';
+import { IFileSystem, ILogger, IWorkspaceConfigReader, JournalController } from '../model';
 import { Configuration } from '../vscode/conf';
 import { Parser } from '../journal/parser';
 import { Writer } from '../journal/writer';
@@ -43,8 +43,8 @@ export class Ctrl implements JournalController {
     private _inject!: Inject;
     private _fs!: IFileSystem;
 
-    constructor(vscodeConfig: vscode.WorkspaceConfiguration) {
-        this._config = new Configuration(vscodeConfig);
+    constructor(configSource: IWorkspaceConfigReader) {
+        this._config = new Configuration(configSource);
     }
 
     public initServices(logger: ILogger): void {

--- a/src/vscode/conf.ts
+++ b/src/vscode/conf.ts
@@ -22,7 +22,7 @@ import * as os from 'os';
 import * as Path from 'path';
 import { Util } from '..';
 import { isNotNullOrUndefined, isNullOrUndefined } from '../util';
-import { HeaderTemplate, InlineTemplate, ScopedTemplate, SCOPE_DEFAULT } from '../model';
+import { HeaderTemplate, InlineTemplate, IWorkspaceConfigReader, ScopedTemplate, SCOPE_DEFAULT } from '../model';
 import { IRawConfigProvider, TemplateService } from './template-service';
 
 export { SCOPE_DEFAULT };
@@ -88,7 +88,7 @@ export class Configuration implements IRawConfigProvider {
     private readonly tpl: TemplateService = new TemplateService(this);
 
 
-    constructor(public config: vscode.WorkspaceConfiguration) {
+    constructor(public config: IWorkspaceConfigReader) {
 
     }
 
@@ -144,7 +144,7 @@ export class Configuration implements IRawConfigProvider {
     }
 
     public getNavigationMode(): NavigationMode {
-        return (vscode.workspace.getConfiguration('journal').get<string>('navigation.mode') ?? 'existing') as NavigationMode;
+        return (this.config.get<string>('navigation.mode') ?? 'existing') as NavigationMode;
     }
 
     /**
@@ -286,7 +286,7 @@ export class Configuration implements IRawConfigProvider {
         }
 
         let ext: string | undefined = this.config.get<string>('ext');
-        ext = (isNullOrUndefined(ext) && (ext!.length === 0)) ? 'md' : ext!;
+        ext = (isNullOrUndefined(ext) || (ext!.length === 0)) ? 'md' : ext!;
 
         if (ext.startsWith(".")) { ext = ext.substring(1, ext.length); }
 
@@ -316,7 +316,7 @@ export class Configuration implements IRawConfigProvider {
         }
 
         if (isNullOrUndefined(result) || result!.length === 0) {
-            result = defaultPatternDefinition.entries.path;
+            result = defaultPatternDefinition.notes.path;
         }
 
         return result!;
@@ -422,13 +422,12 @@ export class Configuration implements IRawConfigProvider {
         return (isNullOrUndefined(result) || result!.length === 0) ? defaultPatternDefinition.weeklyNotes!.file : result!;
     }
 
-    /** Scoped fallback reads notes.file — preserves existing getWeekFilePattern behavior. */
     public getWeekFilePatternRaw(_scopeId?: string): string {
         const scope = this.resolveScope(_scopeId);
         const result: string | undefined = scope === SCOPE_DEFAULT
             ? this.config.get<PatternDefinition>("patterns")?.weeks?.file
-            : this.config.get<ScopeDefinition[]>("scopes")?.filter(sd => sd.name === scope).pop()?.patterns?.notes?.file;
-        return (isNullOrUndefined(result) || result!.length === 0) ? defaultPatternDefinition.notes.file : result!;
+            : this.config.get<ScopeDefinition[]>("scopes")?.filter(sd => sd.name === scope).pop()?.patterns?.weeks?.file;
+        return (isNullOrUndefined(result) || result!.length === 0) ? defaultPatternDefinition.weeks.file : result!;
     }
 
     /** Scoped fallback reads entries.path — preserves existing getWeekPathPattern behavior. */

--- a/src/vscode/template-service.ts
+++ b/src/vscode/template-service.ts
@@ -166,7 +166,7 @@ export class TemplateService {
     }
 
     public async getWeeklyTemplate(week: Number, scopeId?: string) {
-        return this.raw.loadInlineTemplate("weekly", "#  Week ${week}\n\n", this.resolveScope(scopeId))
+        return this.raw.loadInlineTemplate("weekly", "# Week ${week}\n\n## Tasks\n\n## Notes\n\n## Daily Entries\n\n", this.resolveScope(scopeId))
             .then((sp: ScopedTemplate) => {
                 sp.value = sp.template;
                 sp.value = replaceVariableValue("week", week + "", sp.value);


### PR DESCRIPTION
## Summary

- Introduce `IWorkspaceConfigReader` interface and `FakeWorkspaceConfig` test double so tests construct `Ctrl` with an in-memory settings map instead of mutating `vscode.workspace.getConfiguration('journal')`
- Remove all `config.update()` / `ConfigurationTarget` / save+restore patterns from 14 test files (~350 lines deleted)
- Fix five latent bugs exposed when VS Code package.json defaults are no longer injected automatically: `getFileExtension` null-guard (`&&`→`||`), `getWeeklyTemplate` fallback missing sections, `getNotesPathPattern` wrong fallback (`entries.path`→`notes.path`), `getWeekFilePatternRaw` wrong fallback (`notes.file`→`weeks.file`), `getNavigationMode` reads from `this.config` instead of `getConfiguration()`

## Test Plan

- [x] 167 tests pass (`npm test`)
- [x] Zero remaining `config.update`, `ConfigurationTarget`, `originalBase/Scopes/Mode/Granularity` in test suite
- [x] `FakeWorkspaceConfig` satisfies `IWorkspaceConfigReader` structurally — production path (`Startup.ts`) unchanged

Closes #202

Spec: [docs/specs/2026-05-19-202-decouple-test-config.md](../blob/develop/docs/specs/2026-05-19-202-decouple-test-config.md)
Plan: [docs/plans/2026-05-19-202-decouple-test-config.md](../blob/develop/docs/plans/2026-05-19-202-decouple-test-config.md)