### PR TITLE
ci: GitHub Actions release pipeline — build & publish .vsix on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build extension
+        run: npm run compile
+
+      - name: Build tests
+        run: npm run compile-tests
+
+      - name: Run extension tests
+        run: xvfb-run -a npm test
+
+      - name: Read version
+        id: package-version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Package extension
+        run: npx @vscode/vsce package
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: v${{ steps.package-version.outputs.version }}
+          name: vscode-journal v${{ steps.package-version.outputs.version }}
+          files: "*.vsix"
+          generate_release_notes: true

--- a/docs/plans/2026-05-19-202-decouple-test-config.md
+++ b/docs/plans/2026-05-19-202-decouple-test-config.md
@@ -1,0 +1,188 @@
+# Plan: Decouple Tests from Global VS Code Configuration State — #202
+
+## Reference spec
+[docs/specs/2026-05-19-202-decouple-test-config.md](../specs/2026-05-19-202-decouple-test-config.md)
+
+## Approach
+Introduce a thin `IWorkspaceConfigReader` interface (single `get<T>` overload pair) so `Configuration` and `Ctrl` can be constructed with a plain object instead of `vscode.WorkspaceConfiguration`. Add `FakeWorkspaceConfig` test double. Refactor 14 test files to build `Ctrl` from `FakeWorkspaceConfig({…})` and delete all `original*` state variables + `afterEach` blocks that only reset config state.
+
+Trade-off: `FakeWorkspaceConfig` is a flat dictionary lookup. `Configuration` exclusively reads top-level keys (confirmed: `base`, `locale`, `ext`, `scopes`, `patterns`, `templates`, `weeklySync`, `navigation.mode`, `dev`, `openInNewEditorGroup`, `syntax-highlighting`, `entryGranularity`, `tpl-*`) — no nested path reads — so flat lookup is safe and no special path parser is needed.
+
+## Steps
+
+### 1 — Add `IWorkspaceConfigReader` to `src/model/interfaces.ts`
+
+Add after the existing interface declarations:
+
+```typescript
+export interface IWorkspaceConfigReader {
+    get<T>(section: string): T | undefined;
+    get<T>(section: string, defaultValue: T): T;
+}
+```
+
+**Why first:** `Configuration` and `Ctrl` import from `../model`; the interface must exist before their constructors are changed. `vscode.WorkspaceConfiguration` satisfies this structurally — TypeScript confirms at compile time that no cast is needed in `Startup.ts`.
+
+### 2 — Update `Configuration` constructor (`src/vscode/conf.ts`)
+
+Change constructor signature:
+```typescript
+// Before
+constructor(vscodeConfig: vscode.WorkspaceConfiguration) {
+    this._config = vscodeConfig;
+}
+// After
+import { IWorkspaceConfigReader } from '../model';
+constructor(private readonly config: IWorkspaceConfigReader) {}
+```
+
+Note: the field is already named `config` throughout `conf.ts` — only the type annotation changes. Remove `vscode.WorkspaceConfiguration` from the constructor parameter type; keep all `this.config.get<…>(…)` call sites unchanged.
+
+**Why:** This is the primary seam. After this change, `Configuration` no longer depends on a VS Code API type.
+
+### 3 — Update `Ctrl` constructor (`src/util/controller.ts`)
+
+```typescript
+// Before
+constructor(vscodeConfig: vscode.WorkspaceConfiguration) {
+    this._config = new Configuration(vscodeConfig);
+}
+// After
+import { IWorkspaceConfigReader } from '../model';
+constructor(configSource: IWorkspaceConfigReader) {
+    this._config = new Configuration(configSource);
+}
+```
+
+**Why:** `Ctrl` is the entry point tests use. Changing its constructor to `IWorkspaceConfigReader` lets tests pass `new FakeWorkspaceConfig(…)` directly.
+
+### 4 — Verify `npm run compile` (structural typing gate)
+
+```bash
+npm run compile
+```
+
+Must exit 0. If `Startup.ts` passes `vscode.workspace.getConfiguration('journal')` to `new Ctrl(…)`, TypeScript will silently accept it — `vscode.WorkspaceConfiguration` structurally satisfies `IWorkspaceConfigReader`. Zero changes expected in `Startup.ts`. Any compile error at this step means `IWorkspaceConfigReader` is missing a method that `Configuration` calls on `this.config`.
+
+### 5 — Create `FakeWorkspaceConfig` (`src/test/fake-workspace-config.ts`)
+
+```typescript
+import { IWorkspaceConfigReader } from '../model';
+
+export class FakeWorkspaceConfig implements IWorkspaceConfigReader {
+    constructor(private readonly settings: Record<string, unknown> = {}) {}
+
+    get<T>(section: string, defaultValue?: T): T | undefined {
+        return (section in this.settings
+            ? this.settings[section]
+            : defaultValue) as T | undefined;
+    }
+}
+```
+
+**Why:** Single implementation used by all 14 test files. Constructor accepts a plain object — tests declare their needed settings inline with no async I/O.
+
+### 6 — Refactor all 14 test files
+
+For each file listed below, apply the same mechanical change:
+
+**Pattern A — module-level `beforeEach` with single `ctrl` per suite:**
+```typescript
+// Before (in beforeEach / before)
+const config = vscode.workspace.getConfiguration('journal');
+await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+const refreshed = vscode.workspace.getConfiguration('journal');
+ctrl = new J.Util.Ctrl(refreshed);
+
+// After
+ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+```
+
+**Pattern B — per-describe `beforeEach` with `original*` save/restore:**
+```typescript
+// Before
+let originalBase: string | undefined;
+beforeEach(async () => {
+    const config = vscode.workspace.getConfiguration('journal');
+    originalBase = config.get<string>('base');
+    await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+    ctrl = new J.Util.Ctrl(vscode.workspace.getConfiguration('journal'));
+});
+afterEach(async () => {
+    await config.update('base', originalBase, vscode.ConfigurationTarget.Workspace);
+});
+
+// After
+beforeEach(() => {
+    ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+});
+// afterEach DELETED (no global state to restore)
+// originalBase variable DELETED
+```
+
+**Caution for `commands-prev-next.test.ts`:** some `afterEach` blocks also restore `vscode.window.showInformationMessage`. Keep those restores — only remove the `config.update` lines and the `original*` config variables.
+
+**Files to refactor:**
+1. `commands-inject.test.ts`
+2. `week-input.test.ts`
+3. `notes-sync.test.ts`
+4. `issue-168-entry-granularity.test.ts`
+5. `commands-entry.test.ts`
+6. `phase1-regression.test.ts`
+7. `commands-prev-next.test.ts`
+8. `read-templates.test.ts`
+9. `issue-185-weekly-sync.test.ts`
+10. `input.test.ts`
+11. `commands-note.test.ts`
+12. `issue-51-remote-create.test.ts`
+13. `commands-weekly.test.ts`
+14. `scan-entries-cache.test.ts`
+
+For each file, also remove any `import … ConfigurationTarget` from the VS Code import once all uses are gone.
+
+### 7 — Verify `npm run compile-tests` and `npm test`
+
+```bash
+npm run compile-tests   # tsc — catches type errors in refactored tests
+npm test                # full suite — confirms all 14 suites pass
+```
+
+Both must exit 0 with zero errors.
+
+## Test scenarios
+
+**T1 — Interface satisfies structurally**
+`npx tsc --noEmit` on `src/vscode/startup.ts` without changing it → zero errors. Proves `vscode.WorkspaceConfiguration` satisfies `IWorkspaceConfigReader`.
+
+**T2 — FakeWorkspaceConfig key lookup**
+`new FakeWorkspaceConfig({ base: '/tmp/x' }).get('base')` returns `'/tmp/x'`.
+`new FakeWorkspaceConfig({}).get('base', 'fallback')` returns `'fallback'`.
+Verifiable in `node -e` without VS Code.
+
+**T3 — No live config mutation in tests**
+`grep -rn "config\.update\|ConfigurationTarget" src/test/suite/` → zero results.
+
+**T4 — No getConfiguration in tests**
+`grep -rn "vscode\.workspace\.getConfiguration" src/test/suite/` → zero results.
+
+**T5 — No dead original\* variables**
+`grep -rn "originalBase\|originalScopes\|originalMode\|originalExt" src/test/suite/` → zero results.
+
+**T6 — Compile clean**
+`npm run compile` → exit 0. `npm run compile-tests` → exit 0.
+
+**T7 — All tests green**
+`npm test` → all suites pass, same count as before.
+
+## Dependencies
+- **#198 must merge first.** After #198 lands, `TemplateService` is behind `IRawConfigProvider`. This plan then completes the isolation story: `FakeWorkspaceConfig` enables constructing `Configuration` without VS Code, which in turn means tests can supply a testable `IRawConfigProvider` (i.e., a real `Configuration(fakeConfig)`) without the Extension Host.
+
+## Risk
+**Risk:** A test currently uses `config.update` mid-test (not just in `beforeEach`) to change settings between assertions. Switching to `FakeWorkspaceConfig` would require constructing a new `ctrl` rather than mutating settings.  
+**Mitigation:** Step 6 audit — read each test file before refactoring. If a mid-test `config.update` is found, split the test into two tests each with its own `ctrl`.
+
+**Risk:** `commands-prev-next.test.ts` `afterEach` blocks contain both config resets AND `showInformationMessage` restores. Partial deletion could leave orphaned `original*` variables.  
+**Mitigation:** T5 grep catches any lingering `original*` variables. Audit `afterEach` content before deleting.
+
+## Rollback
+`git revert <merge-commit>` — no schema, no migration, no data. Pure TypeScript + test change.

--- a/docs/plans/2026-05-19-225-release-pipeline.md
+++ b/docs/plans/2026-05-19-225-release-pipeline.md
@@ -1,0 +1,55 @@
+# Plan: GitHub Actions Release Pipeline (#225)
+
+**Reference spec:** [docs/specs/2026-05-19-225-release-pipeline.md](../specs/2026-05-19-225-release-pipeline.md)
+
+## Approach
+
+Single-job workflow in `.github/workflows/release.yml`. Gate: full build + test must pass before packaging or releasing. Use `softprops/action-gh-release@v2` with `generate_release_notes: true`. Version read from `package.json` via `node -p`. No matrix — single Node 20 run is sufficient for a packaging job (not correctness testing).
+
+Trade-off: single job means no parallelism, but avoids artifact-passing complexity. Reviewer comment noted `upload-artifact` for multi-job design — deferred as out of scope.
+
+## Steps
+
+1. **Create `.github/workflows/release.yml`**
+   - Trigger: `push` to `main` only
+   - `permissions: contents: write`
+   - Single job `release` on `ubuntu-latest`
+   - Steps in order:
+     1. `actions/checkout@v4`
+     2. `actions/setup-node@v4` — node 20, npm cache
+     3. `npm install`
+     4. `npm run compile`
+     5. `npm run compile-tests`
+     6. `xvfb-run -a npm test`
+     7. Read version: `echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT` with `id: package-version`
+     8. `npx @vscode/vsce package`
+     9. `softprops/action-gh-release@v2` — tag `v${{ steps.package-version.outputs.version }}`, name `vscode-journal v<version>`, `files: "*.vsix"`, `generate_release_notes: true`
+
+2. **Verify no conflicts with existing `ci.yml`**
+   - `ci.yml` triggers on `main` too — both will run on merge; that is intentional and acceptable (CI validates, release publishes)
+   - No step overlap that could cause race conditions (releases are idempotent via `softprops`)
+
+## Test Scenarios
+
+| # | Scenario | Type | How to verify |
+|---|----------|------|---------------|
+| 1 | Merge to `main` with passing tests | e2e | Workflow green, GitHub Release `v<version>` created, `.vsix` attached |
+| 2 | Merge to `main` with failing test | e2e | Workflow red at test step, no release created |
+| 3 | Merge to `main` with compile error | e2e | Workflow red at compile step, no release |
+| 4 | Push to `develop` | e2e | Workflow does NOT trigger |
+| 5 | Duplicate version push (same `package.json` version) | e2e | `softprops` updates existing release, no duplicate tag error |
+
+Scenarios 2–5 can be validated by reviewing workflow trigger config and `softprops` docs rather than requiring live test runs.
+
+## Dependencies
+
+None. No other PRs or issues must land first.
+
+## Risk
+
+- `xvfb-run` flakiness on GitHub runners — same risk as existing `ci.yml`; not new
+- `softprops/action-gh-release@v2` pinned to `v2` (floating major) — acceptable for internal tooling; can pin to SHA if policy requires
+
+## Rollback
+
+Delete `.github/workflows/release.yml`. No code changes, no DB migrations. Fully reversible.

--- a/docs/specs/2026-05-19-202-decouple-test-config.md
+++ b/docs/specs/2026-05-19-202-decouple-test-config.md
@@ -1,0 +1,92 @@
+# Spec: Decouple Tests from Global VS Code Configuration State — #202
+
+## Goal
+Make `Configuration` and `Ctrl` constructible without a live `vscode.WorkspaceConfiguration`, so tests supply settings as plain objects rather than mutating VS Code's global workspace config.
+
+## Why now
+14 test files call `vscode.workspace.getConfiguration('journal')` and `config.update(…, ConfigurationTarget.Workspace)` to inject test values. This approach: (a) mutates global VS Code state, (b) is slow (each `update` is an async I/O write), and (c) creates test-order coupling — a test that crashes before teardown can leave dirty settings that break the next test. Must land after #198: once `TemplateService` lives behind `IRawConfigProvider`, the only remaining VS Code coupling in the resolution layer is the `Configuration` constructor seam. Fixing that seam makes both `TemplateService` and `Configuration` independently testable without the Extension Host.
+
+## In scope
+- New `IWorkspaceConfigReader` interface (two `get<T>` overloads only) in `src/model/interfaces.ts`
+- `Configuration` constructor changed from `vscode.WorkspaceConfiguration` → `IWorkspaceConfigReader`
+- `Ctrl` constructor changed from `vscode.WorkspaceConfiguration` → `IWorkspaceConfigReader` (structural subtype — production callers in `Startup` pass `vscode.WorkspaceConfiguration` unchanged)
+- `FakeWorkspaceConfig` test double in `src/test/fake-workspace-config.ts`
+- Refactor all 14 affected test files: replace `vscode.workspace.getConfiguration` + `config.update` setup with `new FakeWorkspaceConfig({ … })`
+- Remove `ConfigurationTarget` imports from all test files
+
+## Out of scope
+- Writing new headless `TemplateService` unit tests (separate issue)
+- Changes to `IConfiguration` interface
+- Infrastructure seams / `IFileSystem` (#212)
+- Further DI decomposition of `Ctrl` (#208)
+- Any change to `Startup.ts` or production extension code
+
+## Acceptance criteria
+1. `IWorkspaceConfigReader` declared in `src/model/interfaces.ts`; `vscode.WorkspaceConfiguration` satisfies it structurally (no cast needed)
+2. `Configuration` constructor signature: `constructor(raw: IWorkspaceConfigReader)`
+3. `Ctrl` constructor signature: `constructor(configSource: IWorkspaceConfigReader)`
+4. `FakeWorkspaceConfig` in `src/test/fake-workspace-config.ts`; constructor accepts `Record<string, unknown>`
+5. Zero `vscode.workspace.getConfiguration` + `config.update` calls remain in any `src/test/suite/**` file
+6. Zero `ConfigurationTarget` imports remain in any `src/test/suite/**` file
+7. `npm run compile` exits 0, `npm test` passes (all existing tests green)
+
+## Entities / contracts
+
+### `IWorkspaceConfigReader` (new, `src/model/interfaces.ts`)
+```typescript
+export interface IWorkspaceConfigReader {
+    get<T>(section: string): T | undefined;
+    get<T>(section: string, defaultValue: T): T;
+}
+```
+`vscode.WorkspaceConfiguration` satisfies this structurally. No cast needed in `Startup.ts`.
+
+### `FakeWorkspaceConfig` (new, `src/test/fake-workspace-config.ts`)
+```typescript
+export class FakeWorkspaceConfig implements IWorkspaceConfigReader {
+    constructor(private readonly settings: Record<string, unknown> = {}) {}
+    get<T>(section: string, defaultValue?: T): T | undefined {
+        return (section in this.settings ? this.settings[section] : defaultValue) as T | undefined;
+    }
+}
+```
+
+### `Configuration` constructor (changed, `src/vscode/conf.ts`)
+```typescript
+// Before: constructor(vscodeConfig: vscode.WorkspaceConfiguration)
+// After:  constructor(private readonly config: IWorkspaceConfigReader)
+```
+Import `IWorkspaceConfigReader` from `../model`. Remove the `vscode.WorkspaceConfiguration` reference from this constructor.
+
+### `Ctrl` constructor (changed, `src/util/controller.ts`)
+```typescript
+// Before: constructor(vscodeConfig: vscode.WorkspaceConfiguration)
+// After:  constructor(configSource: IWorkspaceConfigReader)
+```
+
+### Test setup pattern (changed in all 14 test files)
+```typescript
+// Before
+const config = vscode.workspace.getConfiguration('journal');
+await config.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
+const refreshed = vscode.workspace.getConfiguration('journal');
+const ctrl = new J.Util.Ctrl(refreshed);
+
+// After
+const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+```
+
+## Affected test files (14)
+`commands-inject.test.ts`, `week-input.test.ts`, `notes-sync.test.ts`,
+`issue-168-entry-granularity.test.ts`, `commands-entry.test.ts`, `phase1-regression.test.ts`,
+`commands-prev-next.test.ts`, `read-templates.test.ts`, `issue-185-weekly-sync.test.ts`,
+`input.test.ts`, `commands-note.test.ts`, `issue-51-remote-create.test.ts`,
+`commands-weekly.test.ts`, `scan-entries-cache.test.ts`
+
+## Open questions
+None.
+
+## Related issues
+- **Blocked by #198** (extract TemplateService — `IRawConfigProvider` seam must land first; #202 then completes the test isolation story)
+- Related to #212 (infrastructure seams / `IFileSystem`)
+- Related to #208 (constructor injection)

--- a/docs/specs/2026-05-19-225-release-pipeline.md
+++ b/docs/specs/2026-05-19-225-release-pipeline.md
@@ -1,0 +1,52 @@
+# Spec: GitHub Actions Release Pipeline (#225)
+
+## Goal
+
+Automatically build and publish a `.vsix` artifact as a GitHub Release on every merge to `main`, enabling manual installation without a Marketplace publish step.
+
+## Why Now
+
+There is no current way to download a built extension artifact. Users and testers must clone and build locally. A GitHub Release with the `.vsix` attached makes every stable build downloadable in one click.
+
+## In Scope
+
+- New workflow file `.github/workflows/release.yml`
+- Trigger: `push` to `main` only (not PRs, not `develop`)
+- Build steps: `npm install` → `npm run compile` → `npm run compile-tests` → `xvfb-run -a npm test` → `vsce package`
+- Read version from `package.json` (no external version-bump step)
+- Create GitHub Release tagged `v<version>` (e.g. `v1.0.3`)
+  - Release title: `vscode-journal v<version>`
+  - Body: auto-generated from tag (or minimal static message)
+  - Asset: the built `.vsix` file
+- Use `softprops/action-gh-release` for the release step (simpler than `gh release create` in CI)
+- Use default `GITHUB_TOKEN` (no PAT needed — same repo release)
+- Fail the entire workflow (no release created) if any earlier step fails
+
+## Out of Scope
+
+- Publishing to VS Code Marketplace (`vsce publish`) — separate issue
+- Automated version bumping or changelog generation
+- Matrix builds (single Node LTS is enough for packaging)
+
+## Acceptance Criteria (observable)
+
+1. Push a commit to `main` → workflow run appears in Actions tab
+2. Run succeeds → GitHub Release `v<version>` created with `.vsix` attached
+3. Run fails (compile error or test failure) → no release created, workflow red
+4. Release already exists for this version → workflow should NOT duplicate-tag (handled by `softprops/action-gh-release` which updates existing releases by default; acceptable for now)
+
+## Constraints
+
+- Tests require a display server: existing CI uses `xvfb-run -a npm test` on `ubuntu-latest` — same approach here
+- `vsce` must be available: install via `npm install -g @vscode/vsce` or use `npx vsce`
+- Node version: pin to `20` (current LTS, consistent with CI matrix minimum)
+- `GITHUB_TOKEN` needs `contents: write` permission to create releases — must be declared explicitly in the workflow `permissions` block (GitHub now requires this for GITHUB_TOKEN write access in Actions)
+
+## Open Questions
+
+None after issue body review.
+
+## Related
+
+- No cross-issue blockers
+- Out-of-scope follow-up: Marketplace publish (no issue yet)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on push to `main`
- Full build + test gate (`compile` → `compile-tests` → `xvfb-run npm test`) before packaging
- Reads version from `package.json`, tags release `v<version>`, attaches `.vsix` as asset
- Uses `softprops/action-gh-release` pinned to SHA `3bb1273` (reviewed: floating `v2` risk noted in plan)

## References

- Closes #225
- Spec: [`docs/specs/2026-05-19-225-release-pipeline.md`](../blob/develop/docs/specs/2026-05-19-225-release-pipeline.md)
- Plan: [`docs/plans/2026-05-19-225-release-pipeline.md`](../blob/develop/docs/plans/2026-05-19-225-release-pipeline.md)

## Test plan

- [ ] Merge to `main` → Actions tab shows `Release` workflow run → GitHub Release `v<version>` created with `.vsix` attached
- [ ] Introduce compile error → workflow fails before release step → no release created
- [ ] Push to `develop` → `Release` workflow does NOT trigger (only `CI` triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)