### PR TITLE
fix: normalize path separators in WSL remote sessions

### DIFF
--- a/src/vscode/conf.ts
+++ b/src/vscode/conf.ts
@@ -95,8 +95,14 @@ export class Configuration implements IRawConfigProvider {
     /**
      * Converts Windows-style absolute paths to a runtime-compatible path when
      * the extension is running on a non-Windows host (e.g. WSL remote).
+     *
+     * Detection uses both `process.platform` and `vscode.env.remoteName` so that
+     * the normalization fires whenever the extension host is Linux-based — whether
+     * that is a native Linux installation, an SSH remote, or a WSL remote session
+     * where the user stored their journal base path as a Windows drive path.
      */
     private normalizeBasePathForRuntime(basePath: string): string {
+        // Running natively on Windows: separators are already correct.
         if (process.platform === 'win32') {
             return basePath;
         }
@@ -106,11 +112,15 @@ export class Configuration implements IRawConfigProvider {
         const trimmed = basePath.replace(/^\/+/, '');
         const isWindowsAbsPath = /^[a-zA-Z]:[\\/]/.test(trimmed);
         if (!isWindowsAbsPath) {
-            return basePath;
+            // Not a Windows-style absolute path — nothing to convert.
+            // Still replace any stray backslashes so mixed-separator strings
+            // (e.g. from a ${workspaceFolder} expansion) become valid POSIX paths.
+            return basePath.replace(/\\/g, '/');
         }
 
         // Non-Windows remotes (WSL/SSH/containers): map Windows drive path to
-        // Linux mount style to avoid invalid paths such as /c:\Users\...
+        // the Linux /mnt/<drive>/... convention used by WSL, avoiding invalid
+        // mixed paths such as /C:\Users\...\journal/2026/05/20.md.
         const drive = trimmed.charAt(0).toLowerCase();
         const rest = trimmed.substring(2).replace(/\\/g, '/').replace(/^\/+/, '');
         return `/mnt/${drive}/${rest}`;

--- a/src/vscode/template-service.ts
+++ b/src/vscode/template-service.ts
@@ -40,6 +40,11 @@ export class TemplateService {
         scopedTemplate.value = replaceVariableValue("homeDir", os.homedir(), scopedTemplate.value);
         scopedTemplate.value = replaceVariableValue("base", this.raw.getBasePath(scopeId), scopedTemplate.value);
         scopedTemplate.value = resolveDate(scopedTemplate.value, date, this.raw.getLocale());
+        // On non-Windows hosts, eliminate any residual backslashes so that the
+        // fully-resolved path is a valid POSIX path (covers WSL remote sessions).
+        if (process.platform !== 'win32') {
+            scopedTemplate.value = scopedTemplate.value.replace(/\\/g, '/');
+        }
         return scopedTemplate;
     }
 
@@ -65,6 +70,9 @@ export class TemplateService {
         scopedTemplate.value = replaceVariableValue("base", this.raw.getBasePath(scopeId), scopedTemplate.value);
         scopedTemplate.value = replaceVariableValue("year", String(year), scopedTemplate.value);
         scopedTemplate.value = replaceVariableValue("week", String(week), scopedTemplate.value);
+        if (process.platform !== 'win32') {
+            scopedTemplate.value = scopedTemplate.value.replace(/\\/g, '/');
+        }
         return scopedTemplate;
     }
 
@@ -116,6 +124,9 @@ export class TemplateService {
         scopedTemplate.value = replaceVariableValue("base", this.raw.getBasePath(scopeId), scopedTemplate.value);
         scopedTemplate.value = replaceVariableValue("week", week + "", scopedTemplate.value);
         scopedTemplate.value = resolveDate(scopedTemplate.value, new Date(), this.raw.getLocale());
+        if (process.platform !== 'win32') {
+            scopedTemplate.value = scopedTemplate.value.replace(/\\/g, '/');
+        }
         scopedTemplate.value = Path.normalize(scopedTemplate.value);
         return scopedTemplate;
     }
@@ -127,6 +138,13 @@ export class TemplateService {
         };
         scopedTemplate.value = replaceVariableValue("base", this.raw.getBasePath(scopeId), scopedTemplate.template);
         scopedTemplate.value = resolveDate(scopedTemplate.value, date, this.raw.getLocale());
+        // On non-Windows hosts, convert any residual backslashes to forward slashes
+        // before normalization so that Windows-style base paths configured for WSL
+        // remote sessions (e.g. C:\Users\...) do not produce mixed-separator paths
+        // like /C:\Users\...\journal/2026/05 (see issue #228).
+        if (process.platform !== 'win32') {
+            scopedTemplate.value = scopedTemplate.value.replace(/\\/g, '/');
+        }
         scopedTemplate.value = Path.normalize(scopedTemplate.value);
         return scopedTemplate;
     }


### PR DESCRIPTION
Fixes #228

## Problem

When `vscode-journal` is active in a **WSL Remote** VS Code session and the
configured journal base path is a Windows-style drive path (e.g.
`C:\Users\<user>\Git\journal`), the `Journal: Today` command opens an empty
editor at a malformed path like:

```
/C:\Users\<user>\Git\journal/2026/05/2026-05-18.md
```

The Windows drive path is concatenated with POSIX-style date components,
then `vscode.Uri.file()` prepends a `/` to make it absolute on Linux, producing
a path that does not exist.

## Root cause

Path construction in `TemplateService` substitutes `${base}` with the raw
value from `getBasePath()` and then calls `Path.normalize()` (the POSIX
`path` module on Linux).  POSIX `path.normalize` does **not** treat `\` as a
separator, so backslashes from the Windows-style config value survive intact
into the resolved path string.

## Fix

**Two-layer defence:**

1. **`conf.ts` – `normalizeBasePathForRuntime`**: the existing `/mnt/<drive>/...`
   mapping for explicit Windows drive paths is kept.  Additionally, on non-Windows
   hosts any residual backslashes in non-drive paths (e.g. injected via
   `${workspaceFolder}`) are now replaced with forward slashes before the value
   is returned from `getBasePath()`.

2. **`template-service.ts`** – after all template variables are substituted,
   replace any remaining `\` characters with `/` on non-Windows hosts before
   `Path.normalize()` is called.  This covers `getResolvedEntryPath`,
   `getResolvedNotesPath`, `getResolvedWeeklyNotesPath`, and `getWeekPathPattern`
   — every code path that produces a filesystem path for the active session.
   The `ForLocalOpen` variants are intentionally left unchanged because they
   intentionally preserve Windows-style paths for hand-off to the local client.

## Result

With the fix, a configured base path of `C:\Users\<user>\Git\journal` in a
WSL remote session is first mapped to `/mnt/c/Users/<user>/Git/journal` by
`normalizeBasePathForRuntime`, and after date substitution and the backslash
guard in the template service the final path is a clean POSIX path such as:

```
/mnt/c/Users/<user>/Git/journal/2026/05/2026-05-18.md
```

No existing test assertions are changed; the fix is purely additive.