### PR TITLE
refactor: kill J namespace barrel (Phase 1, #234)

### DIFF
--- a/src/commands/copy-task.ts
+++ b/src/commands/copy-task.ts
@@ -19,7 +19,8 @@
 
 import moment = require('moment');
 import * as vscode from 'vscode';
-import * as J from '..';
+import { InlineString, InlineTemplate } from '../model';
+import { Ctrl } from '../util';
 
 export enum ShiftTarget {
     nextWorkingDay,
@@ -42,13 +43,13 @@ export class CopyTaskCommand implements vscode.Command {
     command: string = "journal.commands.copy-task";
 
 
-    protected constructor(public ctrl: J.Util.Ctrl) { }
+    protected constructor(public ctrl: Ctrl) { }
 
     public async dispose(): Promise<void> {
         // do nothing
     }
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
         vscode.commands.registerCommand(cmd.command, (document, range, target) => cmd.execute(document, range, target));
         return cmd;
@@ -88,9 +89,9 @@ export class CopyTaskCommand implements vscode.Command {
 
     private async insertTaskToEntry(taskString: string, date: Date) {
         const doc: vscode.TextDocument = await this.ctrl.reader.loadEntryForDay(date);
-        const tpl: J.Model.InlineTemplate = await this.ctrl.config.getTaskInlineTemplate();
+        const tpl: InlineTemplate = await this.ctrl.config.getTaskInlineTemplate();
         const pos = this.ctrl.inject.computePositionForInput(doc, tpl);
-        const inlineString: J.Model.InlineString = await this.ctrl.inject.buildInlineString(doc, tpl, ["${input}", taskString]);
+        const inlineString: InlineString = await this.ctrl.inject.buildInlineString(doc, tpl, ["${input}", taskString]);
         this.ctrl.inject.injectInlineString(inlineString);
 
         doc.save();

--- a/src/commands/open-journal-workspace.ts
+++ b/src/commands/open-journal-workspace.ts
@@ -18,7 +18,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Ctrl } from '../util';
 import { isRemoteSession, toLocalFileUri } from '../journal/paths';
 
 
@@ -27,13 +27,13 @@ export class OpenJournalWorkspaceCommand implements vscode.Command, vscode.Dispo
     command: string = 'journal.open';
 
 
-    protected constructor(public ctrl: J.Util.Ctrl) { }
+    protected constructor(public ctrl: Ctrl) { }
 
     public async dispose(): Promise<void> {
         // do nothing
     }
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
         vscode.commands.registerCommand(cmd.command, () => cmd.openWorkspace());
         return cmd;

--- a/src/commands/open-next-entry.ts
+++ b/src/commands/open-next-entry.ts
@@ -10,7 +10,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
 import { daysBetween, findAdjacentEntry, getAdjacentWeekInput, resolveAnchor, Mode } from '../journal/navigation';
 
@@ -18,7 +19,7 @@ export class OpenNextEntryCommand extends AbstractLoadEntryForDateCommand {
     title: string = "Open the next journal entry";
     command: string = "journal.openNext";
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
         vscode.commands.registerCommand(cmd.command, () => cmd.run());
         return cmd;
@@ -36,7 +37,7 @@ export class OpenNextEntryCommand extends AbstractLoadEntryForDateCommand {
             await vscode.window.showInformationMessage(vscode.l10n.t("No later journal entry found."));
             return;
         }
-        const input = new J.Model.Input();
+        const input = new Input();
         input.date = target;
         input.scope = anchor.scope;
         await this.execute(input);

--- a/src/commands/open-previous-entry.ts
+++ b/src/commands/open-previous-entry.ts
@@ -10,7 +10,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
 import { daysBetween, findAdjacentEntry, getAdjacentWeekInput, resolveAnchor, Mode } from '../journal/navigation';
 
@@ -18,7 +19,7 @@ export class OpenPreviousEntryCommand extends AbstractLoadEntryForDateCommand {
     title: string = "Open the previous journal entry";
     command: string = "journal.openPrevious";
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
         vscode.commands.registerCommand(cmd.command, () => cmd.run());
         return cmd;
@@ -36,7 +37,7 @@ export class OpenPreviousEntryCommand extends AbstractLoadEntryForDateCommand {
             await vscode.window.showInformationMessage(vscode.l10n.t("No earlier journal entry found."));
             return;
         }
-        const input = new J.Model.Input();
+        const input = new Input();
         input.date = target;
         input.scope = anchor.scope;
         await this.execute(input);

--- a/src/commands/print-current-time.ts
+++ b/src/commands/print-current-time.ts
@@ -18,20 +18,21 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { ScopedTemplate } from '../model';
+import { Ctrl } from '../util';
 
 
 export class PrintTimeCommand implements vscode.Command, vscode.Disposable {
     title: string = "Print current time";
     command: string = "journal.printTime";
 
-    protected constructor(public ctrl: J.Util.Ctrl) {}
+    protected constructor(public ctrl: Ctrl) {}
 
     public async dispose(): Promise<void> {
         // do nothing
     }
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl); 
         vscode.commands.registerCommand(cmd.command, () => cmd.printTime());
         return cmd; 
@@ -47,7 +48,7 @@ export class PrintTimeCommand implements vscode.Command, vscode.Disposable {
             let editor: vscode.TextEditor = <vscode.TextEditor>vscode.window.activeTextEditor;
 
             // Todo: identify scope of the active editot
-            let template: J.Model.ScopedTemplate = await this.ctrl.config.getTimeStringTemplate();
+            let template: ScopedTemplate = await this.ctrl.config.getTimeStringTemplate();
 
             let currentPosition: vscode.Position = editor.selection.active;
 

--- a/src/commands/print-duration-between-selected-times.ts
+++ b/src/commands/print-duration-between-selected-times.ts
@@ -19,20 +19,20 @@
 
 import moment = require('moment');
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Ctrl, isNullOrUndefined } from '../util';
 
 
 export class PrintDurationCommand implements vscode.Command, vscode.Disposable {
     title: string = "Print duration between two selected times";
     command: string = "journal.printDuration";
 
-    protected constructor(public ctrl: J.Util.Ctrl) {}
+    protected constructor(public ctrl: Ctrl) {}
 
     public async dispose(): Promise<void> {
         // do nothing
     }
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl); 
         vscode.commands.registerCommand(cmd.command, () => cmd.printDuration());
         return cmd; 
@@ -67,7 +67,7 @@ export class PrintDurationCommand implements vscode.Command, vscode.Disposable {
                 let range: vscode.Range | undefined = editor.document.getWordRangeAtPosition(selection.active, regExp);
 
 
-                if (J.Util.isNullOrUndefined(range)) {
+                if (isNullOrUndefined(range)) {
                     target = selection.active;
                     return;
                 }
@@ -111,7 +111,7 @@ export class PrintDurationCommand implements vscode.Command, vscode.Disposable {
                 }
 
                 // parsing glued hours
-                if (J.Util.isNullOrUndefined(start)) {
+                if (isNullOrUndefined(start)) {
                     start = time;
                 } else if (start!.isAfter(time)) {
                     end = start;
@@ -121,9 +121,9 @@ export class PrintDurationCommand implements vscode.Command, vscode.Disposable {
                 }
             });
 
-            if (J.Util.isNullOrUndefined(start)) { throw new Error("No valid start time selected"); }  // tslint:disable-line
-            else if (J.Util.isNullOrUndefined(end)) { throw new Error("No valid end time selected"); }  // tslint:disable-line
-            else if (J.Util.isNullOrUndefined(target)) { throw new Error("No valid target selected for printing the duration."); }  // tslint:disable-line  
+            if (isNullOrUndefined(start)) { throw new Error("No valid start time selected"); }  // tslint:disable-line
+            else if (isNullOrUndefined(end)) { throw new Error("No valid end time selected"); }  // tslint:disable-line
+            else if (isNullOrUndefined(target)) { throw new Error("No valid target selected for printing the duration."); }  // tslint:disable-line  
             else {
                 let duration = moment.duration(start!.diff(end!));
                 let formattedDuration = Math.abs(duration.asHours()).toFixed(2);

--- a/src/commands/print-sum-of-selected-numbers.ts
+++ b/src/commands/print-sum-of-selected-numbers.ts
@@ -18,20 +18,20 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Ctrl, isNullOrUndefined } from '../util';
 
 
 export class PrintSumCommand implements vscode.Command, vscode.Disposable {
     title: string = "Print sum of two selected numbers";
     command: string = "journal.printSum";
 
-    protected constructor(public ctrl: J.Util.Ctrl) {}
+    protected constructor(public ctrl: Ctrl) {}
 
     public async dispose(): Promise<void> {
         // do nothing
     }
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl); 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute());
         return cmd; 
@@ -53,7 +53,7 @@ export class PrintSumCommand implements vscode.Command, vscode.Disposable {
             editor.selections.forEach((selection: vscode.Selection) => {
                 let range: vscode.Range | undefined = editor.document.getWordRangeAtPosition(selection.active, regExp);
 
-                if (J.Util.isNullOrUndefined(range)) {
+                if (isNullOrUndefined(range)) {
                     target = selection.active;
                     return;
                 }
@@ -76,7 +76,7 @@ export class PrintSumCommand implements vscode.Command, vscode.Disposable {
             });
 
             if (numbers.length < 2) { throw Error("You have to select at least two numbers"); }  // tslint:disable-line
-            else if (J.Util.isNullOrUndefined(target!)) { throw Error("No valid target selected for printing the sum."); }  // tslint:disable-line  
+            else if (isNullOrUndefined(target!)) { throw Error("No valid target selected for printing the sum."); }  // tslint:disable-line  
             else {
                 let result: string = numbers.reduce((previous, current) => previous + current).toString();
                 this.ctrl.inject.injectString(editor.document, result + "", target!);

--- a/src/commands/show-entry-for-date.ts
+++ b/src/commands/show-entry-for-date.ts
@@ -18,7 +18,9 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { LoadNotes } from '../features';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { NoteInput, SelectedInput, ScopedTemplate } from '../model';
 import { getWeekFromURIAndConfig, isRemoteSession, toLocalFileUri } from '../journal/paths';
 import { SyncDailyLinks } from '../features/sync/sync-daily-links';
@@ -26,7 +28,7 @@ import { SyncDailyLinks } from '../features/sync/sync-daily-links';
 
 export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
 
-    constructor(public ctrl: J.Util.Ctrl) { }
+    constructor(public ctrl: Ctrl) { }
 
     public async dispose(): Promise<void> {
         // do nothing
@@ -36,7 +38,7 @@ export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
      * Implements commands "yesterday", "today", "yesterday", where the input is predefined (no input box appears)
      * @param offset 
      */
-    public async execute(input: J.Model.Input): Promise<void> {
+    public async execute(input: Input): Promise<void> {
         try {
             if (await this.promptLocalOrRemoteInRemoteSession(input)) {
                 return;
@@ -52,7 +54,7 @@ export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
         }
     }
 
-    private async promptLocalOrRemoteInRemoteSession(input: J.Model.Input): Promise<boolean> {
+    private async promptLocalOrRemoteInRemoteSession(input: Input): Promise<boolean> {
         if (!isRemoteSession()) {
             return false;
         }
@@ -78,7 +80,7 @@ export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
         return false;
     }
 
-    private async openLocalJournal(input: J.Model.Input): Promise<void> {
+    private async openLocalJournal(input: Input): Promise<void> {
         const localBase = this.ctrl.config.getBasePathForLocalOpen();
         let targetPath = localBase;
 
@@ -117,14 +119,14 @@ export class AbstractLoadEntryForDateCommand implements vscode.Disposable {
      * Expects any user input from the magic input and either opens the file or creates it. 
      * @param input 
      */
-    protected async loadPageForInput(input: J.Model.Input): Promise<vscode.TextDocument> {
+    protected async loadPageForInput(input: Input): Promise<vscode.TextDocument> {
 
         if (input instanceof SelectedInput) {
             // we just load the path
             return this.ctrl.ui.openDocument((<SelectedInput>input).path);
         } if (input instanceof NoteInput) {
             // we create or load the notes
-            return new J.Features.LoadNotes(input, this.ctrl).loadWithPath(input.path);
+            return new LoadNotes(input, this.ctrl).loadWithPath(input.path);
 
         } else {
             return this.ctrl.reader.loadEntryForInput(input)

--- a/src/commands/show-entry-for-input.ts
+++ b/src/commands/show-entry-for-input.ts
@@ -18,7 +18,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
 
 
@@ -26,7 +27,7 @@ export class ShowEntryForInputCommand extends AbstractLoadEntryForDateCommand {
     title: string = "Show journal entry for given user input";
     command: string = "journal.day";
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
         vscode.commands.registerCommand(cmd.command, () => cmd.execute());
         return cmd;
@@ -41,7 +42,7 @@ export class ShowEntryForInputCommand extends AbstractLoadEntryForDateCommand {
     public async execute(): Promise<void> {
         this.ctrl.logger.trace("Executing command: ", this.command);
 
-        const input: J.Model.Input = await this.ctrl.ui.getUserInputWithValidation(); 
+        const input: Input = await this.ctrl.ui.getUserInputWithValidation(); 
         super.execute(input); 
     }
 

--- a/src/commands/show-entry-for-today.ts
+++ b/src/commands/show-entry-for-today.ts
@@ -18,7 +18,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
 
 
@@ -27,10 +28,10 @@ export class ShowEntryForTodayCommand extends AbstractLoadEntryForDateCommand  {
     command: string = "journal.today";
 
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
 
-        let input = new J.Model.Input();
+        let input = new Input();
         input.offset = 0;
 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));

--- a/src/commands/show-entry-for-tomorrow.ts
+++ b/src/commands/show-entry-for-tomorrow.ts
@@ -18,7 +18,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
 
 
@@ -27,10 +28,10 @@ export class ShowEntryForTomorrowCommand extends AbstractLoadEntryForDateCommand
     command: string = "journal.tomorrow";
 
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
 
-        let input = new J.Model.Input();
+        let input = new Input();
         input.offset = 1;
 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));

--- a/src/commands/show-entry-for-yesterday.ts
+++ b/src/commands/show-entry-for-yesterday.ts
@@ -18,7 +18,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { Input } from '../model';
+import { Ctrl } from '../util';
 import { AbstractLoadEntryForDateCommand } from './show-entry-for-date';
 
 
@@ -27,10 +28,10 @@ export class ShowEntryForYesterdayCommand  extends AbstractLoadEntryForDateComma
     command: string = "journal.yesterday";
 
 
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl);
 
-        let input = new J.Model.Input();
+        let input = new Input();
         input.offset = -1;
 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute(input));

--- a/src/commands/show-note.ts
+++ b/src/commands/show-note.ts
@@ -18,7 +18,9 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { LoadNotes } from '../features';
+import { Input, NoteInput } from '../model';
+import { Ctrl } from '../util';
 
 
 export class ShowNoteCommand implements vscode.Command, vscode.Disposable {
@@ -26,13 +28,13 @@ export class ShowNoteCommand implements vscode.Command, vscode.Disposable {
     command: string = 'journal.note';
 
 
-    protected constructor(public ctrl: J.Util.Ctrl) { }
+    protected constructor(public ctrl: Ctrl) { }
 
     public async dispose(): Promise<void> {
         // do nothing
     }
     
-    public static create(ctrl: J.Util.Ctrl): vscode.Disposable {
+    public static create(ctrl: Ctrl): vscode.Disposable {
         const cmd = new this(ctrl); 
         vscode.commands.registerCommand(cmd.command, () => cmd.execute());
         return cmd; 
@@ -48,9 +50,9 @@ export class ShowNoteCommand implements vscode.Command, vscode.Disposable {
 
         try {
             const userInput: string = await this.ctrl.ui.getUserInput("Enter title for new note");
-            let parsedInput: J.Model.Input = await this.ctrl.parser.parseInput(userInput);
+            let parsedInput: Input = await this.ctrl.parser.parseInput(userInput);
 
-            const doc: vscode.TextDocument = await new J.Features.LoadNotes(parsedInput as J.Model.NoteInput, this.ctrl).load();
+            const doc: vscode.TextDocument = await new LoadNotes(parsedInput as NoteInput, this.ctrl).load();
             await this.ctrl.ui.showDocument(doc);
 
            

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,10 +20,10 @@
 
 
 import * as vscode from 'vscode';
-import * as J from './';
+import { Configuration, Startup } from './vscode';
 
-export var journalStartup: J.VSCode.Startup;
-export var journalConfiguration: J.VSCode.Configuration;
+export var journalStartup: Startup;
+export var journalConfiguration: Configuration;
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
         console.time("startup");
 
         let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("journal");
-        journalStartup = new J.VSCode.Startup(config);
+        journalStartup = new Startup(config);
         journalStartup.run(context); 
         
         // return public API of this extension

--- a/src/features/entries/load-note.ts
+++ b/src/features/entries/load-note.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Input, NoteInput } from '../../model';
+import { Ctrl, fileExists } from '../../util';
 
 /**
  * Feature responsible for creating (if needed) and loading notes given a user input as title. 
@@ -8,7 +9,7 @@ import * as J from '../..';
  
 export class LoadNotes {
 
-    constructor(public input: J.Model.NoteInput, public ctrl: J.Util.Ctrl) {
+    constructor(public input: NoteInput, public ctrl: Ctrl) {
 
     }
 
@@ -25,7 +26,7 @@ export class LoadNotes {
         let document : vscode.TextDocument = await this.loadNote(path, content);
 
         // inject reference to new note in the target day's journal page (offset from input, defaults to today)
-        const entryInput = new J.Model.Input(this.input.offset);
+        const entryInput = new Input(this.input.offset);
         entryInput.date = this.input.date;
         entryInput.scope = this.input.scope;
         await this.ctrl.reader.loadEntryForInput(entryInput)
@@ -45,7 +46,7 @@ export class LoadNotes {
     public async loadNote(path: string, content: string): Promise<vscode.TextDocument> {
         this.ctrl.logger.trace("Entering loadNote() in  features/load-note.ts for path: ", path);
 
-        const exists = await J.Util.fileExists(this.ctrl.fs, path);
+        const exists = await fileExists(this.ctrl.fs, path);
         if (exists) {
             return this.ctrl.ui.openDocument(path);
         }

--- a/src/features/entries/scan-entries.ts
+++ b/src/features/entries/scan-entries.ts
@@ -1,15 +1,15 @@
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { inferType } from '../../journal';
+import { FileEntry, IConfiguration, IFileSystem, ILogger, Input, JFileType, JournalPageType, ScopeDirectory } from '../../model';
 import * as Path from 'path';
 import { SCOPE_DEFAULT } from '../../vscode';
-import { FileEntry, IConfiguration, IFileSystem, ILogger, JFileType } from '../../model';
 
 export interface DecoratedQuickPickItem extends vscode.QuickPickItem {
-    parsedInput?: J.Model.Input;
+    parsedInput?: Input;
     replace?: boolean;
     path: string;
-    pickItem?: J.Model.JournalPageType;
-    fileEntry?: J.Model.FileEntry;
+    pickItem?: JournalPageType;
+    fileEntry?: FileEntry;
 }
 
 export interface TimedQuickPick extends vscode.QuickPick<DecoratedQuickPickItem> {
@@ -24,7 +24,7 @@ export interface TimedQuickPick extends vscode.QuickPick<DecoratedQuickPickItem>
 */
 export class ScanEntries {
 
-    private cache: Map<String, J.Model.FileEntry>;
+    private cache: Map<String, FileEntry>;
     constructor(private config: IConfiguration, private logger: ILogger, private fs: IFileSystem) {
         this.cache = new Map();
     }
@@ -45,7 +45,7 @@ export class ScanEntries {
      * @param directories 
      * @returns 
      */
-    public async getPreviouslyAccessedFilesSync(thresholdInMs: number, directories: J.Model.ScopeDirectory[]): Promise<J.Model.FileEntry[]> {
+    public async getPreviouslyAccessedFilesSync(thresholdInMs: number, directories: ScopeDirectory[]): Promise<FileEntry[]> {
 
         this.logger.trace("Entering getPreviousJournalFilesSync() in actions/reader.ts");
 
@@ -63,9 +63,9 @@ export class ScanEntries {
                 continue;
             }
 
-            await this.walkDir(directory.path, thresholdInMs, (entries: J.Model.FileEntry[]) => {
+            await this.walkDir(directory.path, thresholdInMs, (entries: FileEntry[]) => {
                 entries.forEach(entry => {
-                    entry.type = J.Journal.inferType(Path.parse(entry.path), { extension: this.config.getFileExtension() });
+                    entry.type = inferType(Path.parse(entry.path), { extension: this.config.getFileExtension() });
                     entry.scope = directory.scope;
                     this.cache.set(entry.path, entry);
                 });
@@ -86,7 +86,7 @@ export class ScanEntries {
      * @returns {Q.Promise<[string]>}
      * @memberof Reader
      */
-    public async getPreviouslyAccessedFiles(thresholdInMs: number, callback: Function, picker: any, type: J.Model.JournalPageType, directories: Set<J.Model.ScopeDirectory>): Promise<void> {
+    public async getPreviouslyAccessedFiles(thresholdInMs: number, callback: Function, picker: any, type: JournalPageType, directories: Set<ScopeDirectory>): Promise<void> {
 
         // go into base directory, find all files changed within the last 40 days
         // for each file, check if it is an entry, a note or an attachment
@@ -127,7 +127,7 @@ export class ScanEntries {
     }
 
 
-    private async scanDirectory(thresholdInMs: number, callback: Function, picker: any, type: J.Model.JournalPageType, directory: J.Model.ScopeDirectory): Promise<void> {
+    private async scanDirectory(thresholdInMs: number, callback: Function, picker: any, type: JournalPageType, directory: ScopeDirectory): Promise<void> {
         try {
             await this.fs.stat(directory.path);
         } catch {
@@ -135,9 +135,9 @@ export class ScanEntries {
             return;
         }
 
-        await this.walkDir(directory.path, thresholdInMs, (entries: J.Model.FileEntry[]) => {
+        await this.walkDir(directory.path, thresholdInMs, (entries: FileEntry[]) => {
             entries.forEach(fe => {
-                fe.type = J.Journal.inferType(Path.parse(fe.path), { extension: this.config.getFileExtension() });
+                fe.type = inferType(Path.parse(fe.path), { extension: this.config.getFileExtension() });
                 fe.scope = directory.scope;
                 if (!this.cache.has(fe.path)) {
                     this.cache.set(fe.path, fe);

--- a/src/features/entries/show-pick-list.ts
+++ b/src/features/entries/show-pick-list.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as J from '../..';
+
 
 /**
  * Feature responsible for scanning the journal and notes folders and collecting the items displayed in the picklist

--- a/src/features/entries/weekly-entry-watcher.ts
+++ b/src/features/entries/weekly-entry-watcher.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 import { getDatesOfISOWeek } from '../../util/dates';
 import { getWeekFromURIAndConfig } from '../../journal/paths';
 import { SyncDailyLinks } from '../sync/sync-daily-links';
@@ -18,7 +18,7 @@ export class WeeklyEntryWatcher implements vscode.Disposable {
     private readonly editorListener: vscode.Disposable;
 
     constructor(
-        public ctrl: J.Util.Ctrl,
+        public ctrl: Ctrl,
         public sync: SyncDailyLinks
     ) {
         this.editorListener = vscode.window.onDidChangeActiveTextEditor(

--- a/src/features/sync/sync-daily-links.ts
+++ b/src/features/sync/sync-daily-links.ts
@@ -1,13 +1,14 @@
 import * as vscode from 'vscode';
 import * as Path from 'path';
-import * as J from '../..';
+import { getDateFromURIAndConfig } from '../../journal';
+import { Ctrl } from '../../util';
 import { getDatesOfISOWeek, replaceVariableValue } from '../../util';
 import { resolveDate } from '../../journal/template-engine';
 import { fileExists } from '../../util/fs-exists';
 
 export class SyncDailyLinks {
 
-    constructor(public ctrl: J.Util.Ctrl) { }
+    constructor(public ctrl: Ctrl) { }
 
     /**
      * Orchestrates the full sync cycle for a weekly document: find existing
@@ -74,7 +75,7 @@ export class SyncDailyLinks {
 
         const lines: string[] = [];
         for (const uri of dailies) {
-            const date = await J.Journal.getDateFromURIAndConfig(uri.fsPath, this.ctrl.config);
+            const date = await getDateFromURIAndConfig(uri.fsPath, this.ctrl.config);
             const relativePath = Path.relative(weeklyDir, uri.fsPath).replace(/\\/g, '/');
 
             let line = tpl.template;

--- a/src/features/sync/sync-note-links.ts
+++ b/src/features/sync/sync-note-links.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { InlineString } from '../../model';
+import { Ctrl, isNullOrUndefined } from '../../util';
 import * as Path from 'path';
 
 
@@ -9,7 +10,7 @@ import * as Path from 'path';
  */
 export class SyncNoteLinks {
 
-    constructor(public ctrl: J.Util.Ctrl) {
+    constructor(public ctrl: Ctrl) {
     }
 
     /**
@@ -30,8 +31,8 @@ export class SyncNoteLinks {
                 this.getFilesInNotesFolderAllScopes(doc, date)
             ]);
 
-            const promises: Promise<J.Model.InlineString>[] = foundFiles
-                .filter(file => J.Util.isNullOrUndefined(referencedFiles.find(match => match.fsPath === file.fsPath)))
+            const promises: Promise<InlineString>[] = foundFiles
+                .filter(file => isNullOrUndefined(referencedFiles.find(match => match.fsPath === file.fsPath)))
                 .map(file => {
                     this.ctrl.logger.debug("injectAttachmentLinks() - File link not present in entry: ", file);
                     return this.buildReference(doc, file);
@@ -176,7 +177,7 @@ export class SyncNoteLinks {
  * @param doc the document which we will inject into
  * @param file the referenced path
  */
-    private async buildReference(doc: vscode.TextDocument, file: vscode.Uri): Promise<J.Model.InlineString> {
+    private async buildReference(doc: vscode.TextDocument, file: vscode.Uri): Promise<InlineString> {
         this.ctrl.logger.trace("Entering injectReference() in ext/inject.ts for document: ", doc.fileName, " and file ", file);
 
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,9 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with vscode-journal.  If not, see <http://www.gnu.org/licenses/>.
-// 
-export * as VSCode    from './vscode';
-export * as Model     from './model';
-export * as Journal   from './journal';
-export * as Util      from './util';
-export * as Commands  from './commands';
-export * as UI        from './ui';
-export * as Features  from './features';
+//
+// The `J.*` namespace barrel was removed in #234 (Phase 1). Import named
+// symbols directly from the submodule barrels (`./vscode`, `./model`,
+// `./journal`, `./util`, `./commands`, `./ui`, `./features`) instead.
+// This file is intentionally left empty to break the root import cycle.
+export {};

--- a/src/journal/paths.ts
+++ b/src/journal/paths.ts
@@ -20,7 +20,8 @@
 
 import * as Path from 'path';
 import * as vscode from 'vscode';
-import * as J from '..';
+import { JournalPageType } from '../model';
+import { Configuration } from '../vscode';
 import { getDayAsString, prefixZero } from '../util/strings';
 import { isNullOrUndefined } from '../util/util';
 import { toMomentFormat } from './template-engine';
@@ -106,7 +107,7 @@ export async function getDateFromURI(uri: string, pathTemplate: string, fileTemp
  * 
  * @param entryPath 
  */
-export async function getDateFromURIAndConfig(entryPath: string, configCtrl: J.VSCode.Configuration): Promise<Date> {
+export async function getDateFromURIAndConfig(entryPath: string, configCtrl: Configuration): Promise<Date> {
     const pathTpl = (await configCtrl.getResolvedEntryPath(new Date())).template;
     const entryTpl = (await configCtrl.getEntryFilePattern(new Date())).template;
     const base = (await configCtrl.getBasePath());
@@ -177,14 +178,14 @@ export interface InferTypeContext {
     extension: string;
 }
 
-export function inferType(entry: Path.ParsedPath, ctx: InferTypeContext): J.Model.JournalPageType {
+export function inferType(entry: Path.ParsedPath, ctx: InferTypeContext): JournalPageType {
 
     if (!entry.ext.endsWith(ctx.extension)) {
-        return J.Model.JournalPageType.attachment;
+        return JournalPageType.attachment;
     } else if (entry.name.match(/^[\d\-_]+$/)) {
-        return J.Model.JournalPageType.entry;
+        return JournalPageType.entry;
     } else {
-        return J.Model.JournalPageType.note;
+        return JournalPageType.note;
     }
 
 
@@ -211,7 +212,7 @@ export function resolvePath(pathname: string, filename: string): string {
  */
 export async function getWeekFromURIAndConfig(
     uri: vscode.Uri,
-    config: J.VSCode.Configuration
+    config: Configuration
 ): Promise<{ week: number; year: number; scope: string } | undefined> {
     const ext = config.getFileExtension();
     const escapedExt = ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/model/files.ts
+++ b/src/model/files.ts
@@ -1,5 +1,5 @@
 
-import * as J from './..';
+import { JournalPageType } from './';
 
 export interface FileEntry {
     path: string;
@@ -8,5 +8,5 @@ export interface FileEntry {
     updateAt: number;
     createdAt: number;
     accessedAt: number; 
-    type?: J.Model.JournalPageType;
+    type?: JournalPageType;
 }

--- a/src/test/suite/codeaction-tasks.test.ts
+++ b/src/test/suite/codeaction-tasks.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { OpenTaskActions } from '../../ui/codeactions/for-open-tasks';
 import { CompletedTaskActions } from '../../ui/codeactions/for-completed-tasks';
-import * as J from '../..';
+import { InlineTemplate, ScopedTemplate } from '../../model';
 import { createMockCtrl, openEditor } from './command-test-helpers';
 
 function makeRange(line: number, startChar: number, endChar: number): vscode.Range {
@@ -29,8 +29,8 @@ suite('Code actions — task state transitions', function () {
             const token = new vscode.CancellationTokenSource().token;
             const ctrl = createMockCtrl({
                 config: {
-                    getTaskInlineTemplate: async () => ({ template: '- [ ] ${input}', value: '- [ ] ${input}' } as J.Model.InlineTemplate),
-                    getTimeStringTemplate: async () => ({ value: '12:34' } as J.Model.ScopedTemplate),
+                    getTaskInlineTemplate: async () => ({ template: '- [ ] ${input}', value: '- [ ] ${input}' } as InlineTemplate),
+                    getTimeStringTemplate: async () => ({ value: '12:34' } as ScopedTemplate),
                     getBasePath: () => '/tmp/journal-tests',
                     getBasePathForLocalOpen: () => '/tmp/journal-tests'
                 }

--- a/src/test/suite/command-test-helpers.ts
+++ b/src/test/suite/command-test-helpers.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { InlineString, InlineTemplate, Input, NoteInput, ScopedTemplate } from '../../model';
 import { TestLogger } from '../test-logger';
 
 export type MockCtrl = any;
@@ -12,23 +12,23 @@ export function createMockCtrl(overrides: Partial<MockCtrl> = {}): MockCtrl {
         ui: {
             showDocument: async (_doc: vscode.TextDocument) => undefined,
             showError: (msg: string) => calls.showError.push(msg),
-            getUserInputWithValidation: async () => new J.Model.Input(),
+            getUserInputWithValidation: async () => new Input(),
             getUserInput: async () => 'note title'
         },
         reader: {
-            loadEntryForInput: async (_input: J.Model.Input) => ({ uri: vscode.Uri.file('/tmp/test.md') } as vscode.TextDocument),
+            loadEntryForInput: async (_input: Input) => ({ uri: vscode.Uri.file('/tmp/test.md') } as vscode.TextDocument),
             loadEntryForDay: async (_date: Date) => ({ save: async () => true } as unknown as vscode.TextDocument)
         },
         inject: {
-            injectInput: async (doc: vscode.TextDocument, _input: J.Model.Input) => doc,
+            injectInput: async (doc: vscode.TextDocument, _input: Input) => doc,
             injectString: (_doc: vscode.TextDocument, _text: string, _target: vscode.Position) => undefined,
-            computePositionForInput: (_doc: vscode.TextDocument, _tpl: J.Model.InlineTemplate) => new vscode.Position(0, 0),
-            buildInlineString: async (_doc: vscode.TextDocument, _tpl: J.Model.InlineTemplate, vars: string[]) => ({ value: vars[1] } as J.Model.InlineString),
-            injectInlineString: (_inline: J.Model.InlineString) => undefined
+            computePositionForInput: (_doc: vscode.TextDocument, _tpl: InlineTemplate) => new vscode.Position(0, 0),
+            buildInlineString: async (_doc: vscode.TextDocument, _tpl: InlineTemplate, vars: string[]) => ({ value: vars[1] } as InlineString),
+            injectInlineString: (_inline: InlineString) => undefined
         },
         config: {
-            getTimeStringTemplate: async () => ({ value: '12:34' } as J.Model.ScopedTemplate),
-            getTaskInlineTemplate: async () => ({ value: '- [ ] ${input}' } as J.Model.InlineTemplate),
+            getTimeStringTemplate: async () => ({ value: '12:34' } as ScopedTemplate),
+            getTaskInlineTemplate: async () => ({ value: '- [ ] ${input}' } as InlineTemplate),
             getBasePath: () => '/tmp/journal-tests',
             getBasePathForLocalOpen: () => '/tmp/journal-tests',
             getFileExtension: () => 'md',
@@ -44,7 +44,7 @@ export function createMockCtrl(overrides: Partial<MockCtrl> = {}): MockCtrl {
         },
         parser: {
             parseInput: async (input: string) => {
-                const parsed = new J.Model.NoteInput();
+                const parsed = new NoteInput();
                 parsed.text = input;
                 return parsed;
             }

--- a/src/test/suite/commands-copy-task.test.ts
+++ b/src/test/suite/commands-copy-task.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { InlineString, InlineTemplate } from '../../model';
 import { ShiftTarget, CopyTaskCommand } from '../../commands/copy-task';
 import { createMockCtrl } from './command-test-helpers';
 
@@ -25,12 +25,12 @@ suite('Command suites - copy task command', () => {
                 }
             },
             config: {
-                getTaskInlineTemplate: async () => ({ value: '- [ ] ${input}' } as J.Model.InlineTemplate)
+                getTaskInlineTemplate: async () => ({ value: '- [ ] ${input}' } as InlineTemplate)
             },
             inject: {
-                computePositionForInput: (_doc: vscode.TextDocument, _tpl: J.Model.InlineTemplate) => new vscode.Position(0, 0),
-                buildInlineString: async (_doc: vscode.TextDocument, _tpl: J.Model.InlineTemplate, vars: string[]) => ({ value: vars[1] } as J.Model.InlineString),
-                injectInlineString: (inline: J.Model.InlineString) => {
+                computePositionForInput: (_doc: vscode.TextDocument, _tpl: InlineTemplate) => new vscode.Position(0, 0),
+                buildInlineString: async (_doc: vscode.TextDocument, _tpl: InlineTemplate, vars: string[]) => ({ value: vars[1] } as InlineString),
+                injectInlineString: (inline: InlineString) => {
                     injectedValues.push((inline as any).value ?? '');
                 }
             }

--- a/src/test/suite/commands-entry.test.ts
+++ b/src/test/suite/commands-entry.test.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Input } from '../../model';
+import { Ctrl } from '../../util';
 import { ShowEntryForInputCommand } from '../../commands/show-entry-for-input';
 import { ShowEntryForTodayCommand } from '../../commands/show-entry-for-today';
 import { ShowEntryForTomorrowCommand } from '../../commands/show-entry-for-tomorrow';
@@ -12,8 +13,8 @@ import { TestLogger } from '../test-logger';
 import { fileExists } from '../../util/fs-exists';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+function buildCtrl(tmpBase: string): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -35,11 +36,11 @@ suite('Command suites - entry commands', () => {
     });
 
     test('ShowEntryForInputCommand loads page and shows document', async () => {
-        const input = new J.Model.Input();
+        const input = new Input();
         input.offset = 2;
         const fakeDoc = { uri: vscode.Uri.file('/tmp/day.md') } as vscode.TextDocument;
 
-        let loadedInput: J.Model.Input | undefined;
+        let loadedInput: Input | undefined;
         let shownDoc: vscode.TextDocument | undefined;
 
         const ctrl = createMockCtrl({
@@ -52,13 +53,13 @@ suite('Command suites - entry commands', () => {
                 showError: (_msg: string) => undefined
             },
             reader: {
-                loadEntryForInput: async (arg: J.Model.Input) => {
+                loadEntryForInput: async (arg: Input) => {
                     loadedInput = arg;
                     return fakeDoc;
                 }
             },
             inject: {
-                injectInput: async (doc: vscode.TextDocument, arg: J.Model.Input) => {
+                injectInput: async (doc: vscode.TextDocument, arg: Input) => {
                     assert.strictEqual(doc, fakeDoc);
                     assert.strictEqual(arg, input);
                     return doc;
@@ -75,7 +76,7 @@ suite('Command suites - entry commands', () => {
     });
 
     test('ShowEntryForInputCommand (memo alias) loads page and shows document', async () => {
-        const input = new J.Model.Input();
+        const input = new Input();
         input.offset = 0;
         const fakeDoc = { uri: vscode.Uri.file('/tmp/memo.md') } as vscode.TextDocument;
 
@@ -91,10 +92,10 @@ suite('Command suites - entry commands', () => {
                 showError: (_msg: string) => undefined
             },
             reader: {
-                loadEntryForInput: async (_arg: J.Model.Input) => fakeDoc
+                loadEntryForInput: async (_arg: Input) => fakeDoc
             },
             inject: {
-                injectInput: async (doc: vscode.TextDocument, _arg: J.Model.Input) => doc
+                injectInput: async (doc: vscode.TextDocument, _arg: Input) => doc
             }
         });
 
@@ -118,13 +119,13 @@ suite('Command suites - entry commands', () => {
 
             const ctrl = createMockCtrl({
                 reader: {
-                    loadEntryForInput: async (arg: J.Model.Input) => {
+                    loadEntryForInput: async (arg: Input) => {
                         seenOffset = arg.offset;
                         return fakeDoc;
                     }
                 },
                 inject: {
-                    injectInput: async (doc: vscode.TextDocument, _arg: J.Model.Input) => doc
+                    injectInput: async (doc: vscode.TextDocument, _arg: Input) => doc
                 },
                 ui: {
                     showDocument: async (_doc: vscode.TextDocument) => undefined,
@@ -133,7 +134,7 @@ suite('Command suites - entry commands', () => {
             });
 
             const cmd = new (testCase.CommandType as any)(ctrl) as ShowEntryForTodayCommand;
-            const input2 = new J.Model.Input();
+            const input2 = new Input();
             input2.offset = testCase.expected;
             await cmd.execute(input2);
 
@@ -172,7 +173,7 @@ suite('Command suites - entry commands', () => {
                     isWindowsStyleBaseConfigured: () => true
                 },
                 reader: {
-                    loadEntryForInput: async (_arg: J.Model.Input) => {
+                    loadEntryForInput: async (_arg: Input) => {
                         loadCalled = true;
                         return { uri: vscode.Uri.file('/tmp/never.md') } as vscode.TextDocument;
                     }
@@ -184,7 +185,7 @@ suite('Command suites - entry commands', () => {
             });
 
             const cmd = new (ShowEntryForTodayCommand as any)(ctrl) as ShowEntryForTodayCommand;
-            const input = new J.Model.Input();
+            const input = new Input();
             input.offset = 0;
             await cmd.execute(input);
 
@@ -205,7 +206,7 @@ suite('Entry commands — real filesystem', function () {
     this.slow(8000);
 
     let tmpBase: string;
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
@@ -221,7 +222,7 @@ suite('Entry commands — real filesystem', function () {
     });
 
     test('happy: ShowEntryForTodayCommand creates today\'s entry file', async () => {
-        const input = new J.Model.Input(0);
+        const input = new Input(0);
         const cmd = new (ShowEntryForTodayCommand as any)(ctrl) as ShowEntryForTodayCommand;
         await cmd.execute(input);
 
@@ -236,7 +237,7 @@ suite('Entry commands — real filesystem', function () {
     });
 
     test('happy: ShowEntryForYesterdayCommand creates yesterday\'s entry file', async () => {
-        const input = new J.Model.Input(-1);
+        const input = new Input(-1);
         const cmd = new (ShowEntryForYesterdayCommand as any)(ctrl) as ShowEntryForYesterdayCommand;
         await cmd.execute(input);
 
@@ -252,7 +253,7 @@ suite('Entry commands — real filesystem', function () {
     });
 
     test('happy: ShowEntryForTomorrowCommand creates tomorrow\'s entry file', async () => {
-        const input = new J.Model.Input(1);
+        const input = new Input(1);
         const cmd = new (ShowEntryForTomorrowCommand as any)(ctrl) as ShowEntryForTomorrowCommand;
         await cmd.execute(input);
 
@@ -272,7 +273,7 @@ suite('Entry commands — real filesystem', function () {
         (ctrl.reader as any).loadEntryForInput = async () => { throw new Error('simulated reader failure'); };
         (ctrl.ui as any).showError = async (_msg: string) => { errorCalled = true; };
 
-        const input = new J.Model.Input(0);
+        const input = new Input(0);
         const cmd = new (ShowEntryForTodayCommand as any)(ctrl) as ShowEntryForTodayCommand;
         await cmd.execute(input);
 

--- a/src/test/suite/commands-inject.test.ts
+++ b/src/test/suite/commands-inject.test.ts
@@ -2,12 +2,13 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Input } from '../../model';
+import { Ctrl } from '../../util';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+function buildCtrl(tmpBase: string): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -17,7 +18,7 @@ suite('Inject — memo and task insertion', function () {
     this.slow(5000);
 
     let tmpBase: string;
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
@@ -35,7 +36,7 @@ suite('Inject — memo and task insertion', function () {
         const doc = await ctrl.reader.loadEntryForDay(new Date());
         assert.ok(doc, 'expected today\'s entry document');
 
-        const input = new J.Model.Input(0);
+        const input = new Input(0);
         input.flags = 'memo';
         input.text = 'lorem ipsum memo';
 
@@ -51,7 +52,7 @@ suite('Inject — memo and task insertion', function () {
         const doc = await ctrl.reader.loadEntryForDay(new Date());
         assert.ok(doc, 'expected today\'s entry document');
 
-        const input = new J.Model.Input(0);
+        const input = new Input(0);
         input.flags = 'task';
         input.text = 'implement something';
 
@@ -67,7 +68,7 @@ suite('Inject — memo and task insertion', function () {
         const doc = await ctrl.reader.loadEntryForDay(new Date());
         const contentBefore = doc.getText();
 
-        const input = new J.Model.Input(0);
+        const input = new Input(0);
         // hasMemo() requires text.length > 0 — empty text causes early return
         input.flags = 'memo';
         input.text = '';

--- a/src/test/suite/commands-note.test.ts
+++ b/src/test/suite/commands-note.test.ts
@@ -2,14 +2,14 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 import { ShowNoteCommand } from '../../commands/show-note';
 import { TestLogger } from '../test-logger';
 import { fileExists } from '../../util/fs-exists';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+function buildCtrl(tmpBase: string): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -19,7 +19,7 @@ suite('ShowNoteCommand — note creation', function () {
     this.slow(5000);
 
     let tmpBase: string;
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
     let logger: TestLogger;
 
     setup(async () => {

--- a/src/test/suite/commands-prev-next.test.ts
+++ b/src/test/suite/commands-prev-next.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 import {
@@ -28,8 +28,8 @@ async function seedEntry(base: string, year: number, month: number, day: number,
     return file.fsPath;
 }
 
-function buildCtrl(tmpBase: string, extra: Record<string, unknown> = {}): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase, ...extra }));
+function buildCtrl(tmpBase: string, extra: Record<string, unknown> = {}): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase, ...extra }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -64,7 +64,7 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
 
     suite('helper layer with seeded base', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
 
         setup(async () => {
             tmpBase = path.join(os.tmpdir(), `issue144-base-${Date.now()}`);
@@ -182,7 +182,7 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
 
     suite('command layer', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
         let infoMessages: string[];
         let originalShowInfo: typeof vscode.window.showInformationMessage;
 
@@ -275,7 +275,7 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
 
         let tmpBase: string;
         let workBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
 
         setup(async () => {
             tmpBase = path.join(os.tmpdir(), `issue144-scoped-${Date.now()}`);
@@ -330,7 +330,7 @@ suite('Issue #144 — Open Previous / Open Next navigation', () => {
 
     suite('getAdjacentWeekInput (#200)', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
 
         setup(async () => {
             tmpBase = path.join(os.tmpdir(), `issue200-week-${Date.now()}`);

--- a/src/test/suite/commands-print.test.ts
+++ b/src/test/suite/commands-print.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Input, ScopedTemplate } from '../../model';
 import { PrintTimeCommand } from '../../commands/print-current-time';
 import { PrintSumCommand } from '../../commands/print-sum-of-selected-numbers';
 import { PrintDurationCommand } from '../../commands/print-duration-between-selected-times';
@@ -16,7 +16,7 @@ suite('Command suites - print commands', () => {
 
         const ctrl = createMockCtrl({
             config: {
-                getTimeStringTemplate: async () => ({ value: '08:15' } as J.Model.ScopedTemplate)
+                getTimeStringTemplate: async () => ({ value: '08:15' } as ScopedTemplate)
             },
             inject: {
                 injectString: (_doc: vscode.TextDocument, text: string, target: vscode.Position) => {
@@ -124,7 +124,7 @@ suite('Command suites - print commands', () => {
                 ui: {
                     showError: () => { errorCalled = true; },
                     showDocument: async () => undefined,
-                    getUserInputWithValidation: async () => new J.Model.Input(),
+                    getUserInputWithValidation: async () => new Input(),
                     getUserInput: async () => ''
                 }
             });

--- a/src/test/suite/commands-weekly.test.ts
+++ b/src/test/suite/commands-weekly.test.ts
@@ -2,13 +2,13 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 import { TestLogger } from '../test-logger';
 import { fileExists } from '../../util/fs-exists';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-function buildCtrl(tmpBase: string): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+function buildCtrl(tmpBase: string): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -18,7 +18,7 @@ suite('Weekly entry creation', function () {
     this.slow(5000);
 
     let tmpBase: string;
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
     let logger: TestLogger;
 
     setup(async () => {

--- a/src/test/suite/input.test.ts
+++ b/src/test/suite/input.test.ts
@@ -4,7 +4,8 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Input, NoteInput } from '../../model';
+import { Ctrl } from '../../util';
 import { TestLogger } from '../test-logger';
 import { SCOPE_DEFAULT } from '../../model/config';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
@@ -19,7 +20,7 @@ suite('Open Journal Entries', () => {
 	})
 		;
 	test("Input '+1'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -31,7 +32,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input '2021-05-12'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -42,7 +43,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input '05-12'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -53,7 +54,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input '12'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -64,7 +65,7 @@ suite('Open Journal Entries', () => {
 		;
 
 	test("Input 'next monday'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -75,7 +76,7 @@ suite('Open Journal Entries', () => {
 	});
 
 	test("Input 'next tue'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -85,7 +86,7 @@ suite('Open Journal Entries', () => {
 	});
 
 	test("Input 'last wed'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -96,7 +97,7 @@ suite('Open Journal Entries', () => {
 
 
 	test("Input 'task +1 do this'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -109,7 +110,7 @@ suite('Open Journal Entries', () => {
 	});
 
 	test("Input 'task next wed do this'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 
@@ -127,8 +128,8 @@ suite('Open Journal Entries', () => {
 
 suite('Issue #170 — weekday/month/shortcut prefix collisions', () => {
 
-	async function parse(text: string, locale = ''): Promise<J.Model.Input> {
-		const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig(locale ? { locale } : {}));
+	async function parse(text: string, locale = ''): Promise<Input> {
+		const ctrl = new Ctrl(new FakeWorkspaceConfig(locale ? { locale } : {}));
 		ctrl.initServices(new TestLogger(false));
 		return ctrl.parser.parseInput(text);
 	}
@@ -215,7 +216,7 @@ suite('Issue #170 — weekday/month/shortcut prefix collisions', () => {
 suite('NoteInput.extractScopeAndTags (#210)', () => {
 
 	test("noTags: text without tags stays unchanged, scope defaults", () => {
-		const input = new J.Model.NoteInput();
+		const input = new NoteInput();
 		input.text = "my note";
 		input.extractScopeAndTags([]);
 		assert.strictEqual(input.scope, SCOPE_DEFAULT);
@@ -224,7 +225,7 @@ suite('NoteInput.extractScopeAndTags (#210)', () => {
 	});
 
 	test("namedScopeMatch: matching tag sets scope, strips from text", () => {
-		const input = new J.Model.NoteInput();
+		const input = new NoteInput();
 		input.text = "my note #work ";
 		input.extractScopeAndTags(["work"]);
 		assert.strictEqual(input.scope, "work");
@@ -233,7 +234,7 @@ suite('NoteInput.extractScopeAndTags (#210)', () => {
 	});
 
 	test("noScopeMatch: unknown tag collected but scope stays default", () => {
-		const input = new J.Model.NoteInput();
+		const input = new NoteInput();
 		input.text = "my note #unknown ";
 		input.extractScopeAndTags(["work"]);
 		assert.strictEqual(input.scope, SCOPE_DEFAULT);
@@ -242,7 +243,7 @@ suite('NoteInput.extractScopeAndTags (#210)', () => {
 	});
 
 	test("multipleTags: both tags collected, first matching scope wins", () => {
-		const input = new J.Model.NoteInput();
+		const input = new NoteInput();
 		input.text = "note #work #meeting ";
 		input.extractScopeAndTags(["work"]);
 		assert.strictEqual(input.scope, "work");
@@ -252,7 +253,7 @@ suite('NoteInput.extractScopeAndTags (#210)', () => {
 	});
 
 	test("tagAtEndOfString: tag without trailing space is matched (regex fix)", () => {
-		const input = new J.Model.NoteInput();
+		const input = new NoteInput();
 		input.text = "note #work";
 		input.extractScopeAndTags(["work"]);
 		assert.strictEqual(input.scope, "work");

--- a/src/test/suite/issue-168-entry-granularity.test.ts
+++ b/src/test/suite/issue-168-entry-granularity.test.ts
@@ -3,13 +3,15 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import moment = require('moment');
-import * as J from '../..';
+import { Input } from '../../model';
+import { Ctrl } from '../../util';
+import { Configuration } from '../../vscode';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 import { MatchInput } from '../../journal/match-input';
 
-function buildCtrl(settings: Record<string, unknown>): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig(settings));
+function buildCtrl(settings: Record<string, unknown>): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig(settings));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -19,17 +21,17 @@ suite('Issue #168 — Entry granularity', () => {
 
     suite('Configuration.getEntryGranularity', () => {
         test('defaults to "daily" when setting is unset', () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
+            const conf = new Configuration(new FakeWorkspaceConfig({}));
             assert.strictEqual(conf.getEntryGranularity(), 'daily');
         });
 
         test('returns "weekly" when setting is "weekly"', () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ entryGranularity: 'weekly' }));
+            const conf = new Configuration(new FakeWorkspaceConfig({ entryGranularity: 'weekly' }));
             assert.strictEqual(conf.getEntryGranularity(), 'weekly');
         });
 
         test('returns "daily" for any unknown value (defensive)', () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ entryGranularity: 'monthly' }));
+            const conf = new Configuration(new FakeWorkspaceConfig({ entryGranularity: 'monthly' }));
             assert.strictEqual(conf.getEntryGranularity(), 'daily');
         });
     });
@@ -97,7 +99,7 @@ suite('Issue #168 — Entry granularity', () => {
 
     suite('Default weekly template includes section anchors', () => {
         test('getWeeklyTemplate renders ## Tasks and ## Notes sections', async () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
+            const conf = new Configuration(new FakeWorkspaceConfig({}));
             const tpl = await conf.getWeeklyTemplate(7);
             assert.ok(tpl.value, 'template value should be set');
             assert.ok(tpl.value!.includes('# Week 7'), `expected '# Week 7' in: ${tpl.value}`);
@@ -114,7 +116,7 @@ suite('Issue #168 — Entry granularity', () => {
         });
 
         test('resolves the default weekly notes path with year and week substituted', async () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ base: tmpBase }));
+            const conf = new Configuration(new FakeWorkspaceConfig({ base: tmpBase }));
 
             const resolved = await conf.getResolvedWeeklyNotesPath(20, 2026);
             assert.ok(resolved.value, 'resolved value should be set');
@@ -127,7 +129,7 @@ suite('Issue #168 — Entry granularity', () => {
         });
 
         test('weekly notes file pattern substitutes input', async () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({ base: tmpBase }));
+            const conf = new Configuration(new FakeWorkspaceConfig({ base: tmpBase }));
 
             const filePattern = await conf.getWeeklyNotesFilePattern(20, 2026, 'My_Note');
             assert.ok(filePattern.value, 'file pattern value should be set');
@@ -140,7 +142,7 @@ suite('Issue #168 — Entry granularity', () => {
 
     suite('Parser.resolveNotePathForInput honors granularity', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
 
         setup(async () => {
             tmpBase = path.join(os.tmpdir(), `issue168-notes-${Date.now()}`);
@@ -149,7 +151,7 @@ suite('Issue #168 — Entry granularity', () => {
         test('granularity=daily: notes path uses day-keyed pattern (regression)', async () => {
             ({ ctrl } = buildCtrl({ base: tmpBase, entryGranularity: 'daily' }));
 
-            const input = new J.Model.Input(0);
+            const input = new Input(0);
             input.text = 'My_Note';
             const resolvedPath = await ctrl.parser.resolveNotePathForInput(input);
             const today = new Date();
@@ -163,7 +165,7 @@ suite('Issue #168 — Entry granularity', () => {
         test('granularity=weekly: notes path uses week-keyed pattern', async () => {
             ({ ctrl } = buildCtrl({ base: tmpBase, entryGranularity: 'weekly' }));
 
-            const input = new J.Model.Input(0);
+            const input = new Input(0);
             input.text = 'My_Note';
             const resolvedPath = await ctrl.parser.resolveNotePathForInput(input);
             const today = new Date();

--- a/src/test/suite/issue-185-weekly-sync.test.ts
+++ b/src/test/suite/issue-185-weekly-sync.test.ts
@@ -3,15 +3,16 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import moment = require('moment');
-import * as J from '../..';
+import { Ctrl } from '../../util';
+import { Configuration } from '../../vscode';
 import { SyncDailyLinks } from '../../features/sync/sync-daily-links';
 import { getWeekFromURIAndConfig } from '../../journal/paths';
 import { getDatesOfISOWeek } from '../../util/dates';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
-function buildCtrl(settings: Record<string, unknown>): { ctrl: J.Util.Ctrl; logger: TestLogger } {
-    const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig(settings));
+function buildCtrl(settings: Record<string, unknown>): { ctrl: Ctrl; logger: TestLogger } {
+    const ctrl = new Ctrl(new FakeWorkspaceConfig(settings));
     const logger = new TestLogger(false);
     ctrl.initServices(logger);
     return { ctrl, logger };
@@ -47,7 +48,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('URI helper — getWeekFromURIAndConfig', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
 
         setup(async () => {
             tmpBase = path.join(os.tmpdir(), `issue185-uri-${Date.now()}`);
@@ -82,7 +83,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('Configuration.getWeeklySyncConfig', () => {
         test('returns defaults when setting is unset', async () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
+            const conf = new Configuration(new FakeWorkspaceConfig({}));
             const syncCfg = conf.getWeeklySyncConfig();
             assert.strictEqual(syncCfg.enabled, true);
             assert.strictEqual(syncCfg.anchor, '## Daily Entries');
@@ -93,7 +94,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('SyncDailyLinks — rendering (unit)', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
         let weeklyUri: vscode.Uri;
 
         setup(async () => {
@@ -152,7 +153,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('SyncDailyLinks — integration', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
         let logger: TestLogger;
         let weeklyUri: vscode.Uri;
         const weeklyContent = '# Week 20\n\n## Daily Entries\n\n## Notes\n\n';
@@ -256,7 +257,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('Default weekly template includes ## Daily Entries', () => {
         test('W16 — getWeeklyTemplate includes ## Daily Entries anchor', async () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
+            const conf = new Configuration(new FakeWorkspaceConfig({}));
             const tpl = await conf.getWeeklyTemplate(20);
             assert.ok(tpl.value, 'template value should be set');
             assert.ok(tpl.value!.includes('## Daily Entries'),
@@ -266,7 +267,7 @@ suite('Issue #185 — Weekly daily-link sync', () => {
 
     suite('W17 — #168 regression assertions remain green', () => {
         test('existing weekly template test still passes', async () => {
-            const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
+            const conf = new Configuration(new FakeWorkspaceConfig({}));
             const tpl = await conf.getWeeklyTemplate(7);
             assert.ok(tpl.value, 'template value should be set');
             assert.ok(tpl.value!.includes('# Week 7'), `expected '# Week 7' in: ${tpl.value}`);

--- a/src/test/suite/issue-232-note-offset.test.ts
+++ b/src/test/suite/issue-232-note-offset.test.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Input, NoteInput } from '../../model';
+import { Ctrl } from '../../util';
 import { LoadNotes } from '../../features/entries/load-note';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
@@ -10,13 +11,13 @@ import { FakeWorkspaceConfig } from '../fake-workspace-config';
 suite('Issue #232 — Note linked to specific day via temporal offset', () => {
 
     let tmpBase: string;
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
     let logger: TestLogger;
 
     setup(async () => {
         tmpBase = path.join(os.tmpdir(), `issue232-${Date.now()}`);
         await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
-        ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+        ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
         logger = new TestLogger(false);
         ctrl.initServices(logger);
     });
@@ -29,14 +30,14 @@ suite('Issue #232 — Note linked to specific day via temporal offset', () => {
     test('offset=0 (default) links note to today', async () => {
         const capturedOffsets: number[] = [];
         const orig = ctrl.reader.loadEntryForInput.bind(ctrl.reader);
-        (ctrl.reader as any).loadEntryForInput = async (input: J.Model.Input) => {
+        (ctrl.reader as any).loadEntryForInput = async (input: Input) => {
             capturedOffsets.push(input.offset);
             return orig(input);
         };
 
-        const input = new J.Model.Input(0);
+        const input = new Input(0);
         input.text = 'TodayNote';
-        await new LoadNotes(input as J.Model.NoteInput, ctrl).load();
+        await new LoadNotes(input as NoteInput, ctrl).load();
 
         assert.ok(capturedOffsets.some(o => o === 0), `expected offset 0, got ${JSON.stringify(capturedOffsets)}`);
         assert.strictEqual(logger.errors.length, 0, `errors: ${JSON.stringify(logger.errors)}`);
@@ -45,14 +46,14 @@ suite('Issue #232 — Note linked to specific day via temporal offset', () => {
     test('offset=+2 links note to day-after-tomorrow', async () => {
         const capturedOffsets: number[] = [];
         const orig = ctrl.reader.loadEntryForInput.bind(ctrl.reader);
-        (ctrl.reader as any).loadEntryForInput = async (input: J.Model.Input) => {
+        (ctrl.reader as any).loadEntryForInput = async (input: Input) => {
             capturedOffsets.push(input.offset);
             return orig(input);
         };
 
-        const input = new J.Model.Input(2);
+        const input = new Input(2);
         input.text = 'FutureNote';
-        await new LoadNotes(input as J.Model.NoteInput, ctrl).load();
+        await new LoadNotes(input as NoteInput, ctrl).load();
 
         assert.ok(capturedOffsets.some(o => o === 2), `expected offset 2, got ${JSON.stringify(capturedOffsets)}`);
         assert.strictEqual(logger.errors.length, 0, `errors: ${JSON.stringify(logger.errors)}`);
@@ -61,14 +62,14 @@ suite('Issue #232 — Note linked to specific day via temporal offset', () => {
     test('offset=-1 links note to yesterday', async () => {
         const capturedOffsets: number[] = [];
         const orig = ctrl.reader.loadEntryForInput.bind(ctrl.reader);
-        (ctrl.reader as any).loadEntryForInput = async (input: J.Model.Input) => {
+        (ctrl.reader as any).loadEntryForInput = async (input: Input) => {
             capturedOffsets.push(input.offset);
             return orig(input);
         };
 
-        const input = new J.Model.Input(-1);
+        const input = new Input(-1);
         input.text = 'YesterdayNote';
-        await new LoadNotes(input as J.Model.NoteInput, ctrl).load();
+        await new LoadNotes(input as NoteInput, ctrl).load();
 
         assert.ok(capturedOffsets.some(o => o === -1), `expected offset -1, got ${JSON.stringify(capturedOffsets)}`);
         assert.strictEqual(logger.errors.length, 0, `errors: ${JSON.stringify(logger.errors)}`);
@@ -78,9 +79,9 @@ suite('Issue #232 — Note linked to specific day via temporal offset', () => {
         const today = new Date();
         const future = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 2);
 
-        const inputToday = new J.Model.Input(0);
+        const inputToday = new Input(0);
         inputToday.text = 'SameNote';
-        const inputFuture = new J.Model.Input(2);
+        const inputFuture = new Input(2);
         inputFuture.text = 'SameNote';
 
         const pathToday = await ctrl.parser.resolveNotePathForInput(inputToday);

--- a/src/test/suite/issue-51-remote-create.test.ts
+++ b/src/test/suite/issue-51-remote-create.test.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { NoteInput } from '../../model';
+import { Ctrl } from '../../util';
 import { LoadNotes } from '../../features/entries/load-note';
 import { fileExists } from '../../util/fs-exists';
 import { VscodeFileSystem } from '../../vscode/vscode-fs';
@@ -34,7 +35,7 @@ suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
 
     suite('open-before-create antipattern is gone', () => {
         let tmpBase: string;
-        let ctrl: J.Util.Ctrl;
+        let ctrl: Ctrl;
         let logger: TestLogger;
         let openCallCount: number;
 
@@ -42,7 +43,7 @@ suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
             tmpBase = path.join(os.tmpdir(), `issue51-base-${Date.now()}`);
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(tmpBase));
 
-            ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+            ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
             logger = new TestLogger(false);
             ctrl.initServices(logger);
 
@@ -95,7 +96,7 @@ suite('Issue #51 — Stat-first file creation on remote workspaces', () => {
 
         test('LoadNotes.loadNote does not call openDocument when the note is missing', async () => {
             const notePath = path.join(tmpBase, `note-${Date.now()}.md`);
-            const input = new J.Model.NoteInput();
+            const input = new NoteInput();
             input.text = 'issue51 test note';
             const doc = await new LoadNotes(input, ctrl).loadNote(notePath, '# Test\n');
             assert.ok(doc, 'expected a document');

--- a/src/test/suite/notes-sync.test.ts
+++ b/src/test/suite/notes-sync.test.ts
@@ -6,7 +6,8 @@ import * as path from 'path';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { NoteInput } from '../../model';
+import { Ctrl } from '../../util';
 import { LoadNotes } from '../../features/entries/load-note';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
@@ -23,7 +24,7 @@ suite('Test Notes Syncing', () => {
         await wsConfig.update('base', tmpBase, vscode.ConfigurationTarget.Workspace);
 
         try {
-            let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+            let ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
             ctrl.initServices(new TestLogger(false));
 
             // create a new entry.. remember length
@@ -32,7 +33,7 @@ suite('Test Notes Syncing', () => {
             assert.ok(editor, "Failed to open today's journal");
 
             // create a new note
-            let input = new J.Model.NoteInput();
+            let input = new NoteInput();
             input.text = "This is a sync test note " + Date.now();
             let notesDoc: vscode.TextDocument = await new LoadNotes(input, ctrl).load();
             let notesEditor = await ctrl.ui.showDocument(notesDoc);

--- a/src/test/suite/phase1-regression.test.ts
+++ b/src/test/suite/phase1-regression.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl, Logger } from '../../util';
+import { Configuration } from '../../vscode';
 import { MatchInput } from '../../journal/match-input';
 import { TestLogger } from '../test-logger';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
@@ -9,7 +10,7 @@ suite('Phase 1 — Regression Tests', () => {
 
     // ── 1.1  Weekly template name mismatch (#167) ─────────────────────────
     test('#167 — getWeeklyTemplate resolves the "weekly" template from config', async () => {
-        const conf = new J.VSCode.Configuration(new FakeWorkspaceConfig({}));
+        const conf = new Configuration(new FakeWorkspaceConfig({}));
 
         // The default template in package.json is named "weekly"
         const tpl = await conf.getWeeklyTemplate(7);
@@ -20,7 +21,7 @@ suite('Phase 1 — Regression Tests', () => {
 
     // ── 1.2  MatchInput stale today (#170) ────────────────────────────────
     suite('#170 — MatchInput date freshness & validation', () => {
-        let logger: J.Util.Logger;
+        let logger: Logger;
         let locale: string;
 
         setup(() => {
@@ -94,7 +95,7 @@ suite('Phase 1 — Regression Tests', () => {
     // ── 1.3  Remote workspace support (#94) ───────────────────────────────
     suite('#94 — vscode.workspace.fs file creation', () => {
         test('createSaveLoadTextDocument writes and opens a file via vscode.workspace.fs', async () => {
-            const ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+            const ctrl = new Ctrl(new FakeWorkspaceConfig({}));
             ctrl.initServices(new TestLogger(false));
 
             const tmpDir = require('os').tmpdir();

--- a/src/test/suite/read-templates.test.ts
+++ b/src/test/suite/read-templates.test.ts
@@ -3,16 +3,18 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { LoadNotes } from '../../features';
+import { Input, NoteInput } from '../../model';
+import { Ctrl } from '../../util';
 import { TestLogger } from '../test-logger';
 import { suite, before, test } from 'mocha';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Read templates from configuration', () => {
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
 
     before(() => {
-        ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({
+        ctrl = new Ctrl(new FakeWorkspaceConfig({
             scopes: [
                 {
                     name: 'work',
@@ -47,13 +49,13 @@ suite('Read templates from configuration', () => {
     });
 
     test('Test resolving note paths', async () => {
-        const inPriv = new J.Model.Input(0);
+        const inPriv = new Input(0);
         inPriv.text = "#priv a note created in private scope";
         const pathPriv = await ctrl.parser.resolveNotePathForInput(inPriv);
         const uriPriv = vscode.Uri.file(pathPriv);
 
 
-        const inWork = new J.Model.Input(0);
+        const inWork = new Input(0);
         inWork.text = "#work a note created in work scope";
         const pathWork = await ctrl.parser.resolveNotePathForInput(inWork);
         const uriWork = vscode.Uri.file(pathWork);
@@ -72,7 +74,7 @@ suite('Read templates from configuration', () => {
 
         // create a new note
         const privInput = await ctrl.parser.parseInput("#priv a note created in private scop");
-        let privNotes = await new J.Features.LoadNotes(privInput as J.Model.NoteInput, ctrl);
+        let privNotes = await new LoadNotes(privInput as NoteInput, ctrl);
         let privDoc: vscode.TextDocument = await privNotes.load();
         privDoc = await ctrl.ui.saveDocument(privDoc);
         const privUri = privDoc.uri;
@@ -80,7 +82,7 @@ suite('Read templates from configuration', () => {
 
 
         const workInput = await ctrl.parser.parseInput("#work a note created in work scope");
-        let workDoc: vscode.TextDocument = await new J.Features.LoadNotes(workInput as J.Model.NoteInput, ctrl).load();
+        let workDoc: vscode.TextDocument = await new LoadNotes(workInput as NoteInput, ctrl).load();
         workDoc = await ctrl.ui.saveDocument(workDoc);
         const uriWork = workDoc.uri;
 

--- a/src/test/suite/scan-entries-cache.test.ts
+++ b/src/test/suite/scan-entries-cache.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 import { ScanEntries } from '../../features/entries/scan-entries';
 import { SCOPE_DEFAULT } from '../../vscode';
 import { JournalPageType, ScopeDirectory } from '../../model';
@@ -21,7 +21,7 @@ async function seedEntry(base: string, year: number, month: number, day: number,
 
 suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
     let tmpBase: string;
-    let ctrl: J.Util.Ctrl;
+    let ctrl: Ctrl;
     let scanner: ScanEntries;
     let walkCount: number;
     let originalWalkDir: any;
@@ -34,7 +34,7 @@ suite('Issue #187 — ScanEntries cache short-circuit and invalidation', () => {
         await seedEntry(tmpBase, 2025, 3, 8);
         await seedEntry(tmpBase, 2025, 4, 1);
 
-        ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
+        ctrl = new Ctrl(new FakeWorkspaceConfig({ base: tmpBase }));
         ctrl.initServices(new TestLogger(false));
         scanner = new ScanEntries(ctrl.config, ctrl.logger, ctrl.fs);
 

--- a/src/test/suite/week-input.test.ts
+++ b/src/test/suite/week-input.test.ts
@@ -4,7 +4,7 @@ import moment = require('moment');
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 import { TestLogger } from '../test-logger';
 import { suite, before, test } from 'mocha';
 import { FakeWorkspaceConfig } from '../fake-workspace-config';
@@ -12,10 +12,10 @@ import { FakeWorkspaceConfig } from '../fake-workspace-config';
 
 suite('Open Week Entries', () => {
 	vscode.window.showInformationMessage('Start all tests.');
-	let ctrl: J.Util.Ctrl;
+	let ctrl: Ctrl;
 
 	before(() => {
-		ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 	});
 
@@ -32,7 +32,7 @@ suite('Open Week Entries', () => {
 
 
 	test("Input 'w'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 		let input = await ctrl.parser.parseInput("w");
@@ -46,7 +46,7 @@ suite('Open Week Entries', () => {
 	});
 
 	test("Input 'next week'", async () => {
-		let ctrl = new J.Util.Ctrl(new FakeWorkspaceConfig({}));
+		let ctrl = new Ctrl(new FakeWorkspaceConfig({}));
 		ctrl.initServices(new TestLogger(false));
 
 		const thisWeekInput = await ctrl.parser.parseInput("w");

--- a/src/ui/codeactions/for-completed-tasks.ts
+++ b/src/ui/codeactions/for-completed-tasks.ts
@@ -18,7 +18,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 
 
 /**
@@ -29,7 +29,7 @@ import * as J from '../..';
  * - annotate the task with completion date: '-[x] some text (completed on 2021-05-12 at 12:12)'
  */
 export class CompletedTaskActions implements vscode.CodeActionProvider {
-    private ctrl: J.Util.Ctrl; 
+    private ctrl: Ctrl; 
     private regex = new RegExp(/-\s{0,1}\[\s{0,2}x|X\s{0,2}\].*/g);  
     
 
@@ -38,7 +38,7 @@ export class CompletedTaskActions implements vscode.CodeActionProvider {
 	];
 
 
-    constructor(ctrl: J.Util.Ctrl) {
+    constructor(ctrl: Ctrl) {
         this.ctrl = ctrl; 
     }
 

--- a/src/ui/codeactions/for-open-tasks.ts
+++ b/src/ui/codeactions/for-open-tasks.ts
@@ -19,7 +19,8 @@
 
 import moment = require('moment');
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { InlineTemplate } from '../../model';
+import { Ctrl } from '../../util';
 import { ShiftTarget } from '../../commands/copy-task';
 
 
@@ -31,7 +32,7 @@ import { ShiftTarget } from '../../commands/copy-task';
  * - annotate the task with completion date: '-[x] some text (completed on 2021-05-12 at 12:12)'
  */
 export class OpenTaskActions implements vscode.CodeActionProvider {
-    private ctrl: J.Util.Ctrl;
+    private ctrl: Ctrl;
     private regex = new RegExp(/-\s{0,1}\[\s{0,2}\].*/g);
 
 
@@ -40,7 +41,7 @@ export class OpenTaskActions implements vscode.CodeActionProvider {
     ];
 
 
-    constructor(ctrl: J.Util.Ctrl) {
+    constructor(ctrl: Ctrl) {
         this.ctrl = ctrl;
     }
 
@@ -100,7 +101,7 @@ export class OpenTaskActions implements vscode.CodeActionProvider {
     private async getTaskText(document: vscode.TextDocument, range: vscode.Range | vscode.Selection): Promise<string> {
         const line: vscode.TextLine = document.lineAt(range.start.line);
         let text = line.text.trim();
-        const tpl: J.Model.InlineTemplate = await this.ctrl.config.getTaskInlineTemplate(); 
+        const tpl: InlineTemplate = await this.ctrl.config.getTaskInlineTemplate(); 
 
         // line: - [ ] Task: this is some text  blabla
         // template: - [ ] Task: {$input}  blabla

--- a/src/ui/codelens/migrate-tasks.ts
+++ b/src/ui/codelens/migrate-tasks.ts
@@ -18,7 +18,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 
 
 /**
@@ -31,13 +31,13 @@ import * as J from '../..';
  */
 export class MigrateTasksCodeLens implements vscode.CodeLensProvider {
     private codeLenses: vscode.CodeLens[] = [];
-    private ctrl: J.Util.Ctrl; 
+    private ctrl: Ctrl; 
 
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     
 
 
-    constructor(ctrl: J.Util.Ctrl) {
+    constructor(ctrl: Ctrl) {
         this.ctrl = ctrl; 
 
         vscode.workspace.onDidChangeConfiguration((_) => {

--- a/src/ui/codelens/shift-task.ts
+++ b/src/ui/codelens/shift-task.ts
@@ -18,18 +18,18 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '../..';
+import { Ctrl } from '../../util';
 
 
 export class ShiftTaskCodeLens implements vscode.CodeLensProvider {
     private codeLenses: vscode.CodeLens[] = [];
-    private ctrl: J.Util.Ctrl; 
+    private ctrl: Ctrl; 
 
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     
 
 
-    constructor(ctrl: J.Util.Ctrl) {
+    constructor(ctrl: Ctrl) {
         this.ctrl = ctrl; 
 
         vscode.workspace.onDidChangeConfiguration((_) => {

--- a/src/vscode/conf.ts
+++ b/src/vscode/conf.ts
@@ -20,8 +20,7 @@
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as Path from 'path';
-import { Util } from '..';
-import { isNotNullOrUndefined, isNullOrUndefined } from '../util';
+import { isNotNullOrUndefined, isNullOrUndefined, stringIsNotEmpty } from '../util';
 import { HeaderTemplate, InlineTemplate, IWorkspaceConfigReader, ScopedTemplate, SCOPE_DEFAULT } from '../model';
 import { IRawConfigProvider, TemplateService } from './template-service';
 
@@ -183,7 +182,7 @@ export class Configuration implements IRawConfigProvider {
                     let base: string[] = scopes!.filter(v => v.name === scope)
                         .map(scopeDefinition => scopeDefinition.base)
                         .map(scopedBase => {
-                            if (Util.stringIsNotEmpty(scopedBase)) {
+                            if (stringIsNotEmpty(scopedBase)) {
                                 scopedBase = scopedBase!
                                     .replace("${homeDir}", os.homedir())
                                     .replace("${workspaceRoot}", workspaceRoot)
@@ -237,9 +236,9 @@ export class Configuration implements IRawConfigProvider {
             const base = scopes!
                 .filter(v => v.name === scope)
                 .map(scopeDefinition => scopeDefinition.base)
-                .find(scopedBase => Util.stringIsNotEmpty(scopedBase));
+                .find(scopedBase => stringIsNotEmpty(scopedBase));
 
-            if (Util.stringIsNotEmpty(base)) {
+            if (stringIsNotEmpty(base)) {
                 return base!
                     .replace("${homeDir}", os.homedir())
                     .replace("${workspaceRoot}", workspaceRoot)
@@ -683,20 +682,20 @@ export class Configuration implements IRawConfigProvider {
             pattern = scopeDefinition?.templates?.find(tpl => tpl.name === _id)
                 ?? this.config.get<InlineTemplate[]>("templates")?.find(tpl => tpl.name === _id);
         }
-        if (Util.isNullOrUndefined(pattern)) {
+        if (isNullOrUndefined(pattern)) {
             // #72: legacy config support — moved here so legacy doesn't win when both are set
-            if (Util.stringIsNotEmpty(this.config.get<string>("tpl-" + _id))) {
+            if (stringIsNotEmpty(this.config.get<string>("tpl-" + _id))) {
                 return {
                     name: _id,
                     scope: SCOPE_DEFAULT,
                     template: this.config.get<string>("tpl-" + _id)!,
-                    after: Util.stringIsNotEmpty(this.config.get<string>(_id + '-after')) ? this.config.get<string>(_id + '-after')! : ''
+                    after: stringIsNotEmpty(this.config.get<string>(_id + '-after')) ? this.config.get<string>(_id + '-after')! : ''
                 };
             }
             return { name: _id, scope: SCOPE_DEFAULT, template: _defaultValue, after: '' };
         }
-        if (Util.isNullOrUndefined(pattern?.after)) { pattern!.after = ''; }
-        if (Util.isNullOrUndefined(pattern?.template)) { pattern!.after = _defaultValue; }
+        if (isNullOrUndefined(pattern?.after)) { pattern!.after = ''; }
+        if (isNullOrUndefined(pattern?.template)) { pattern!.after = _defaultValue; }
         return pattern!;
     }
 

--- a/src/vscode/startup.ts
+++ b/src/vscode/startup.ts
@@ -20,18 +20,21 @@
 
 
 import * as vscode from 'vscode';
-import * as J from '..';
+import { OpenJournalWorkspaceCommand, OpenNextEntryCommand, OpenPreviousEntryCommand, PrintDurationCommand, PrintSumCommand, PrintTimeCommand, ShiftTaskCommand, ShowEntryForInputCommand, ShowEntryForTodayCommand, ShowEntryForTomorrowCommand, ShowEntryForYesterdayCommand, ShowNoteCommand } from '../commands';
+import { SyncDailyLinks, SyncNoteLinks, WeeklyEntryWatcher } from '../features';
+import { CompletedTaskActions, MigrateTasksCodeLens, OpenTaskActions } from '../ui';
+import { ConsoleLogger, Ctrl, isNullOrUndefined } from '../util';
+import { Configuration } from './';
 import * as Path from 'path';
-import { isNullOrUndefined } from '../util';
 
 interface TextMateRule { scope: string; settings: any; }
 
 export class Startup {
 
-    private ctrl: J.Util.Ctrl;
+    private ctrl: Ctrl;
 
     constructor(public config: vscode.WorkspaceConfiguration) {
-        this.ctrl = new J.Util.Ctrl(this.config);
+        this.ctrl = new Ctrl(this.config);
     }
 
 
@@ -68,10 +71,10 @@ export class Startup {
         }
     }
 
-    public async registerLoggingChannel(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<J.Util.Ctrl> {
+    public async registerLoggingChannel(ctrl: Ctrl, context: vscode.ExtensionContext): Promise<Ctrl> {
         const channel: vscode.OutputChannel = vscode.window.createOutputChannel("Journal");
         context.subscriptions.push(channel);
-        const logger = new J.Util.ConsoleLogger(ctrl.config, channel);
+        const logger = new ConsoleLogger(ctrl.config, channel);
         ctrl.initServices(logger);
         ctrl.logger.debug("VSCode Journal is starting");
         return ctrl;
@@ -84,43 +87,43 @@ export class Startup {
      * @param context 
      * @returns 
      */
-    public async registerCodeLens(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<J.Util.Ctrl> {
+    public async registerCodeLens(ctrl: Ctrl, context: vscode.ExtensionContext): Promise<Ctrl> {
         const sel: vscode.DocumentSelector = { scheme: 'file', language: 'markdown' };
         context.subscriptions.push(
-            vscode.languages.registerCodeLensProvider(sel, new J.UI.MigrateTasksCodeLens(ctrl))
+            vscode.languages.registerCodeLensProvider(sel, new MigrateTasksCodeLens(ctrl))
         );
         return ctrl;
     }
 
-    public async registerCommands(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<void> {
+    public async registerCommands(ctrl: Ctrl, context: vscode.ExtensionContext): Promise<void> {
         ctrl.logger.trace("Entering registerCommands() in util/startup.ts");
 
 
         try {
             ctrl.reader.onNotesInjected = (doc, date) => {
-                new J.Features.SyncNoteLinks(ctrl).injectAttachmentLinks(doc, date)
+                new SyncNoteLinks(ctrl).injectAttachmentLinks(doc, date)
                     .finally(() => ctrl.logger.trace("Scanning notes completed"));
             };
 
-            const syncDailyLinks = new J.Features.SyncDailyLinks(ctrl);
-            const weeklyEntryWatcher = new J.Features.WeeklyEntryWatcher(ctrl, syncDailyLinks);
+            const syncDailyLinks = new SyncDailyLinks(ctrl);
+            const weeklyEntryWatcher = new WeeklyEntryWatcher(ctrl, syncDailyLinks);
             context.subscriptions.push(weeklyEntryWatcher);
 
             context.subscriptions.push(
-                J.Commands.OpenJournalWorkspaceCommand.create(ctrl),
-                J.Commands.PrintTimeCommand.create(ctrl),
-                J.Commands.PrintSumCommand.create(ctrl),
-                J.Commands.PrintDurationCommand.create(ctrl),
-                J.Commands.ShowEntryForInputCommand.create(ctrl),
+                OpenJournalWorkspaceCommand.create(ctrl),
+                PrintTimeCommand.create(ctrl),
+                PrintSumCommand.create(ctrl),
+                PrintDurationCommand.create(ctrl),
+                ShowEntryForInputCommand.create(ctrl),
                 vscode.commands.registerCommand('journal.memo', () =>
-                    new J.Commands.ShowEntryForInputCommand(ctrl).execute()),
-                J.Commands.ShowEntryForTodayCommand.create(ctrl),
-                J.Commands.ShowEntryForTomorrowCommand.create(ctrl),
-                J.Commands.ShowEntryForYesterdayCommand.create(ctrl),
-                J.Commands.ShowNoteCommand.create(ctrl),
-                J.Commands.ShiftTaskCommand.create(ctrl),
-                J.Commands.OpenPreviousEntryCommand.create(ctrl),
-                J.Commands.OpenNextEntryCommand.create(ctrl)
+                    new ShowEntryForInputCommand(ctrl).execute()),
+                ShowEntryForTodayCommand.create(ctrl),
+                ShowEntryForTomorrowCommand.create(ctrl),
+                ShowEntryForYesterdayCommand.create(ctrl),
+                ShowNoteCommand.create(ctrl),
+                ShiftTaskCommand.create(ctrl),
+                OpenPreviousEntryCommand.create(ctrl),
+                OpenNextEntryCommand.create(ctrl)
             );
 
         } catch (error) {
@@ -130,7 +133,7 @@ export class Startup {
 
     }
 
-    public async registerCacheInvalidation(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<void> {
+    public async registerCacheInvalidation(ctrl: Ctrl, context: vscode.ExtensionContext): Promise<void> {
         try {
             const scanner = ctrl.ui.getScanner();
             context.subscriptions.push(...scanner.registerInvalidationListeners());
@@ -139,15 +142,15 @@ export class Startup {
         }
     }
 
-    public async registerCodeActions(ctrl: J.Util.Ctrl, context: vscode.ExtensionContext): Promise<void> {
+    public async registerCodeActions(ctrl: Ctrl, context: vscode.ExtensionContext): Promise<void> {
         try {
 
             // TODO: add filters only for configured base directories
             const sel: vscode.DocumentSelector = { scheme: 'file', language: 'markdown' };
 
             context.subscriptions.push(
-                vscode.languages.registerCodeActionsProvider(sel, new J.UI.CompletedTaskActions(ctrl)),
-                vscode.languages.registerCodeActionsProvider(sel, new J.UI.OpenTaskActions(ctrl))
+                vscode.languages.registerCodeActionsProvider(sel, new CompletedTaskActions(ctrl)),
+                vscode.languages.registerCodeActionsProvider(sel, new OpenTaskActions(ctrl))
             );
 
         } catch (error) {
@@ -158,7 +161,7 @@ export class Startup {
     }
 
 
-    getConfiguration(): J.VSCode.Configuration {
+    getConfiguration(): Configuration {
         return this.ctrl.config;
     }
 
@@ -168,7 +171,7 @@ export class Startup {
     }
 
 
-    public async registerSyntaxHighlighting(ctrl: J.Util.Ctrl): Promise<J.Util.Ctrl> {
+    public async registerSyntaxHighlighting(ctrl: Ctrl): Promise<Ctrl> {
         if (this.ctrl.config.isSyntaxHighlightingEnabled()) {
             return this.enableSyntaxHighlighting(ctrl);
         } else {
@@ -177,7 +180,7 @@ export class Startup {
     }
 
 
-    public async disableSyntaxHighlighting(ctrl: J.Util.Ctrl): Promise<J.Util.Ctrl> {
+    public async disableSyntaxHighlighting(ctrl: Ctrl): Promise<Ctrl> {
         const tokenColorCustomizations = vscode.workspace.getConfiguration('editor.tokenColorCustomizations');
         if (!tokenColorCustomizations.has("textMateRules")) { return ctrl; }
 
@@ -191,15 +194,15 @@ export class Startup {
     /**
      * Sets default syntax highlighting settings on startup, we try to differentiate between dark and light themes
      *
-     * @param {J.Util.Ctrl} ctrl
+     * @param {Ctrl} ctrl
      * @param {vscode.ExtensionContext} context
-     * @returns {Q.Promise<J.Util.Ctrl>}
+     * @returns {Q.Promise<Ctrl>}
      * @memberof Startup
      */
-    public async enableSyntaxHighlighting(ctrl: J.Util.Ctrl): Promise<J.Util.Ctrl> {
+    public async enableSyntaxHighlighting(ctrl: Ctrl): Promise<Ctrl> {
         const theme: string | undefined = vscode.workspace.getConfiguration().get<string>("workbench.colorTheme");
         let style: string;
-        if (J.Util.isNullOrUndefined(theme) || theme!.search('Light') > -1) { style = "light"; }
+        if (isNullOrUndefined(theme) || theme!.search('Light') > -1) { style = "light"; }
         else if (theme!.search('High Contrast') > -1) { style = "high-contrast"; }
         else { style = "dark"; }
 
@@ -213,7 +216,7 @@ export class Startup {
         if (style.startsWith("high-contrast")) { return ctrl; }
 
         const ext: vscode.Extension<any> | undefined = vscode.extensions.getExtension("pajoma.vscode-journal");
-        if (J.Util.isNullOrUndefined(ext)) { throw Error("Failed to load this extension"); }
+        if (isNullOrUndefined(ext)) { throw Error("Failed to load this extension"); }
 
         const colorConfigDir: string = Path.join(ext!.extensionPath, "res", "colors");
         const rawData = await vscode.workspace.fs.readFile(vscode.Uri.file(Path.join(colorConfigDir, style + ".json")));

--- a/src/vscode/vscode-codelens.ts
+++ b/src/vscode/vscode-codelens.ts
@@ -18,17 +18,17 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as J from '../.';
+import { Ctrl } from '../util';
 
 export class JournalCodeLensProvider implements vscode.CodeLensProvider {
     private codeLenses: vscode.CodeLens[] = [];
-    private ctrl: J.Util.Ctrl; 
+    private ctrl: Ctrl; 
 
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     
 
 
-    constructor(ctrl: J.Util.Ctrl) {
+    constructor(ctrl: Ctrl) {
         this.ctrl = ctrl; 
 
         vscode.workspace.onDidChangeConfiguration((_) => {


### PR DESCRIPTION
**Phase 1 of #234** — package-by-feature restructure.

Removes the `J` namespace barrel that created the root import cycle (`src/index.ts → submodule → src/index.ts`).

## Changes
- Replace `import * as J from '<root>'` + `J.<Sub>.<Sym>` with named imports from each submodule barrel across 47 files.
- Also fixed a non-codemod variant: `import { Util } from '..'` in `vscode/conf.ts`.
- Empty `src/index.ts` (`export {}`) to break the cycle.

## Why behavior-identical
`J.<Sub>.X` already resolved through `src/<sub>/index.ts`. Rewriting to named imports from the same barrel changes resolution path only by dropping the root re-export — no symbol resolves differently.

## Verification
- `npm run compile-tests` (tsc) ✔
- `npm run compile` (esbuild) ✔
- `npm run lint` ✔
- Full suite: **238 passing**, exit 0

## Notes
- Pure mechanical, zero behavior change. Largest diff of the restructure — unblocks Phases 2–5.
- Acceptance: no `import * as J` remains; root barrel reduced to `export {}`.

Refs #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
